### PR TITLE
honour ~/.netrc

### DIFF
--- a/Changes
+++ b/Changes
@@ -852,3 +852,4 @@
            supplied. Just error and exit instead
 * 20191005 Fixed typos in base.pod and recipes.pod
 > 20191006 released 20190914.0
+* 20191009 added .netrc support

--- a/doc/base.pod
+++ b/doc/base.pod
@@ -19,7 +19,7 @@ Deliver a standard test email to user@example.com on port 25 of test-server.exam
 
 =back
 
-Deliver a standard test email, requiring CRAM-MD5 authentication as user me@example.com.  An "X-Test" header will be added to the email body.  The authentication password will be prompted for.
+Deliver a standard test email, requiring CRAM-MD5 authentication as user me@example.com.  An "X-Test" header will be added to the email body.  The authentication password will be prompted for if it cannot be obtained from your L<.netrc|Net::Netrc> file.
 
 =over 4
 
@@ -158,7 +158,7 @@ Options can be supplied via environment variables.  The variables are in the for
     $ SWAKS_OPT_from='fred@example.com'
     $ SWAKS_OPT_h_From='"Fred Example" <fred@example.com>'
 
-Setting a variable to an empty value is the same as specifying it on the command line with no argument.  For instance, setting SWAKS_OPT_server="" would cause Swaks to prompt the use for the server to which to connect at each invocation.
+Setting a variable to an empty value is the same as specifying it on the command line with no argument.  For instance, setting SWAKS_OPT_server="" would cause Swaks to prompt the user for the server to which to connect at each invocation.
 
 Because there is no inherent order in options provided by setting environment variables, the options are sorted before being processed.  This is not a great solution, but it at least defines the behavior, which would be otherwise undefined.  As an example, if both SWAKS_OPT_from and SWAKS_OPT_f were set, the value from SWAKS_OPT_from would be used, because it sorts after SWAKS_OPT_f.  Also as a result of not having an inherent order in environment processing, unsetting options with the "no-" prefix is unreliable.  It works if the option being turned off sorts before "no-", but fails if it sorts after. Because "no-" is primarily meant to operate between config types (for instance, unsetting from the command line an option that was set in a config file), this is not likely to be a problem.
 

--- a/doc/base.pod
+++ b/doc/base.pod
@@ -516,11 +516,13 @@ This option is a compromise between --auth and --auth-optional.  If no common au
 
 =item -au, --auth-user [username]
 
-Provide the username to be used for authentication, or prompt the user for it if no argument is provided.  The string E<lt>E<gt> can be supplied to mean an empty username.
+Provide the username to be used for authentication.  If no username is provided, indicate that Swaks should attempt to find the username via .netrc (requires the Net::Netrc module).  If no username is provided
+ and cannot be found via .netrc,  the user will be prompted to provide one.  The string E<lt>E<gt> can be supplied to mean an empty username.
 
 =item -ap, --auth-password [password]
 
-Provide the password to be used for authentication, or prompt the user for it if no argument is provided.  The string E<lt>E<gt> can be supplied to mean an empty password.
+Provide the password to be used for authentication. If no password is provided, indicate that Swaks should attempt to find the password via .netrc (requires the Net::Netrc module).  If no password is provided
+and cannot be found via .netrc,  the user will be prompted to provide one.  The string E<lt>E<gt> can be supplied to mean an empty password.
 
 =item -ae, --auth-extra [KEYWORD=value[,...]]
 

--- a/swaks
+++ b/swaks
@@ -1347,9 +1347,9 @@ sub unencode_smtp {
 }
 
 sub obtain_from_netrc {
+	return if !avail('netrc');
 	my $field = shift;
 	my $login = shift;
-	require Net::Netrc;
 	my $login =
 	  Net::Netrc->lookup( $G::link{server}, defined $login ? $login : () )
 	  or return;
@@ -1611,6 +1611,7 @@ sub load_dependencies {
 		auth_ntlm       => { name => "AUTH NTLM",                req => ['Authen::NTLM']      },
 		auth_digest_md5 => { name => "AUTH DIGEST-MD5",          req => ['Authen::SASL']      },
 		dns             => { name => "MX Routing",               req => ['Net::DNS']          },
+		netrc           => { name => '~/.netrc support',         req => ['Net::Netrc']        },
 		tls             => { name => "TLS",                      req => ['Net::SSLeay']       },
 		pipe            => { name => "Pipe Transport",           req => ['IPC::Open2']        },
 		socket          => { name => "Socket Transport",         req => ['IO::Socket']        },

--- a/swaks
+++ b/swaks
@@ -1346,6 +1346,16 @@ sub unencode_smtp {
 	}
 }
 
+sub obtain_from_netrc {
+	my $field = shift;
+	my $login = shift;
+	require Net::Netrc;
+	my $login =
+	  Net::Netrc->lookup( $G::link{server}, defined $login ? $login : () )
+	  or return;
+	$login->$field;
+}
+
 sub interact {
 	my $prompt     = shift;
 	my $regexp     = shift;
@@ -3037,11 +3047,17 @@ sub process_args {
 					exit(10);
 				}
 			} else {
-				$n{a_user}   = $o->{auth_user} if (defined($o->{auth_user}));
+				$n{a_user} =
+				  defined $o->{auth_user}
+				  ? $o->{auth_user}
+				  : obtain_from_netrc('login');
 				$n{a_user} ||= interact("Username: ", 'SKIP');
 				$n{a_user}   = '' if ($n{a_user} eq '<>');
 
-				$n{a_pass}   = $o->{auth_pass} if (defined($o->{auth_pass}));
+				$n{a_pass} =
+				  defined $o->{auth_pass}
+				  ? $o->{auth_pass}
+				  : obtain_from_netrc( 'password', $n{a_user} );
 				$n{a_pass} ||= interact("Password: ", 'SKIP', 1);
 				$n{a_pass}   = '' if ($n{a_pass} eq '<>');
 


### PR DESCRIPTION
Currently, one of my use cases for `swaks` is a simple monitoring cronjob including the requirement for authentication.  For security reasons, I do not want to put the password on the command line, but obviously it is no alternative to be prompted for it either.

Therefore I have extended `swaks` so that it will try to obtain the login credentials from my `~/.netrc` using the standard Net::Netrc module if authentication is required but no username
and/or password is given.  You may still turn this off by supplying `-au` respectively `-ap` without an argument.