### PR TITLE
docs: face lift, mobile friendly (600px width)

### DIFF
--- a/doc/faq.html
+++ b/doc/faq.html
@@ -1,184 +1,236 @@
-<html><head><title>Swaks - Swiss Army Knife for SMTP</title>
-<style type="text/css">
-a:link { color: blue }
-a:visited { color: blue }
-a:active { color: navy }
-body {
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 13px;
-    font-style: normal;
-    font-variant: normal;
-    font-weight: normal;
-    line-height: 1.7em;
-}
-</style>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Swaks - Swiss Army Knife for SMTP</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/skeleton/2.0.4/skeleton.min.css" /> <!-- https://cdnjs.com/libraries/skeleton -->
+    <style type="text/css">
+        body { font-family: "Helvetica Neue", Helvetica, Arial, sans-serif }
+        #subheader { font-size: 120% }
+        h5 { padding-top: 0 }
+        a:link { color: blue }
+        a:visited { color: blue }
+        a:active { color: navy }
+        .header { margin-top: 3% }
+        .footer { margin-bottom: 3% }
+        code { font-size: 120% }
+    </style>
 </head>
 <body>
-<table width=100% height=100%><tr><td valign=middle align=center>
-<table cellpadding=3 border=0 width=600>
-<tr><td align=center>
-<a name=swaks>
-<font size=+3><B>Swaks</B> - Swiss Army Knife for SMTP</font>
-</a>
-<br>
-<font size=-1>A scriptable, transaction-oriented SMTP test tool</font>
-</td></tr><tr><td>
-<P><hr><P>
-<font size=+1><B>Occasionally Asked Questions</B></font>
-<P>
-These are questions that I occasionally get asked or I see pop up in a Google query string.
-<P>
-If you are trying to figure out something using Swaks, drop me a line at <a href=mailto:proj-swaks@jetmore.net>proj-swaks@jetmore.net</a>.  Swaks is a low-traffic project and I enjoy making it better, whether it's docs or code or just giving a hint in an email.
-<P>
-<a href=index.html>return to main page</a>
-<P><hr><P>
-</tr></td></table>
+
+<div class="section header">
+    <div class="container">
+        <div class="row">
+            <a name=swaks><h1>Swaks - Swiss Army Knife for SMTP</h1></a>
+            <span id="subheader">A scriptable, transaction-oriented SMTP test tool</span>
+        </div>
+        <hr/>
+    </div>
+</div>
+
+<div class="container">
+    <div class="row">
+        <h4>Occasionally Asked Questions</h4>
+        <p>
+            These are questions that I occasionally get asked or I see pop up in a Google query string.<br/>
+            If you are trying to figure out something using Swaks, drop me a line at <a href=mailto:proj-swaks@jetmore.net>proj-swaks@jetmore.net</a>.  Swaks is a low-traffic project and I enjoy making it better, whether it's docs or code or just giving a hint in an email.
+        </p>
+        <p><a href="./index.html">return to main page</a></p>
+    </div>
+    <hr/>
+
+    <div class="row">
+        <div class="two columns">
+            <b>Table of Contents</b>
+        </div>
+        <div class="ten columns">
+            <ol>
+                <li><a href="#mult_recip">How do I use Swaks to send email to multiple recipients?</a>
+                <li><a href="#adding_header">How do I add a header?</a>
+                <li><a href="#install_macosx">How do I install on Mac OS X?</a>
+                <li><a href="#install_windows">How do I install on Windows?</a>
+                <li><a href="#send_html_email">How do I send HTML email?</a>
+                <li><a href="#bcc">How do I send a BCC email?</a>
+                <li><a href="#support_ipv6">Does Swaks support IPv6?</a>
+            </ol>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="two columns">
+            <b><a name="mult_recip">Multiple Recipients</a></b>
+        </div>
+        <div class="ten columns">
+            <h5>How do I use Swaks to send email to multiple recipients?</h5>
+            <p>
+                Multiple recipients can be specified by passing them as a single argument to the "--to" option.
+                Any of the following will result in mail being sent to both foo@example.net and bar@example.com:
+            </p>
+            <p>
+                Command line:
+                <pre><code>
+    swaks --to foo@example.net,bar@example.com
+                </code></pre>
+            </p>
+            <p>
+                Environment variable:
+                <pre><code>
+    SWAKS_OPT_to='foo@example.net,bar@example.com'
+    swaks
+                </code></pre>
+            </p>
+            <p>
+                Config file:
+                <pre><code>
+    echo "--to foo@example.net,bar@example.com" >> .swaksrc
+    swaks --config .swaksrc
+                </code></pre>
+            </pre>
+            <p>
+                The argument to the --to option is passed deep into the heart of Swaks with no real validation checking.
+                This is done intentionally - because Swaks is meant to be a test tool, oddball values should be allowed.
+                One side effect of this is that including a space after the comma will result in an email address that starts with a comma,
+                which is probably not what you want.
+            </p>
+            <p>
+                There is one additional consideration here.  Since Swaks is oriented around a single SMTP-session per invocation, 
+                it will only ever connect to a single server, even if multiple recipients are specified.  
+                In the example above, both emails will be delivered to the MX server for example.com 
+                (since, as documented, the mail routing for the last domain in the list is used).  
+                This may or may not work, depending on the configuration of email server you are testing.
+            </p>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="two columns">
+            <b><a name="adding_header">Adding Headers</a></b>
+        </div>
+        <div class="ten columns">
+            <h5>How do I add a header?</h5>
+            <p>Use the --add-header option:</p>
+            <pre><code>
+    swaks --add-header "X-Test-Header: foo"
+            </code></pre>
+            <p>
+                There are lots more examples in <a href=http://jetmore.org/john/code/swaks/latest/doc/ref.txt>the spec</a>, 
+                look for --header and --add-header for details and nuance about each.  
+                A quick rule of thumb though is that you want --header to overwrite a header that already exists in your test email, 
+                and you want --add-header to add a completely new header, even if that same header already exists in your test email.
+            </p>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="two columns">
+            <b><a name="install_macosx">Install on Mac OS X</a></b>
+        </div>
+        <div class="ten columns">
+            <h5>How do I install on Mac OS X?</h5>
+            <p>
+                Copy and paste or right-click, save-as works great for me.  If you prefer a package manager, 
+                both <a href="http://www.macports.org/">MacPorts</a> and <a href="http://brew.sh/">Homebrew</a> provide Swaks.
+            </p>
+        </div>
+    </div>
+    
+    <div class="row">
+        <div class="two columns">
+            <b><a name="install_windows">Install on Windows</a></b>
+        </div>
+        <div class="ten columns">
+            <h5>How do I install on Windows?</h5>
+            <p>
+                Swaks has been tested much less on Windows than Mac OS X or Linux (or even Solaris, Swaks' birth-OS), 
+                but it has worked when I tested it.  I installed ActiveState Perl, saved the latest version of Swaks as swaks.pl, 
+                and used ppm to install Perl modules.  It worked fine for me, but if you are having specific issues let me know.
+            </p>
+        </div>
+    </div>
+    
+    <div class="row">
+        <div class="two columns">
+            <b><a name="send_html_email">HTML Email</a></b>
+        </div>
+        <div class="ten columns">
+            <h5>How do I send HTML email?</h5>
+            <p>
+                This really depends on what you want to do.  At its base, Swaks is agnostic about what it sends in its DATA section, 
+                so you can craft whatever email you want and use it as the DATA of the message using the --data option.  
+                This is the best route for testing, where you usually have a fixed set of test cases to run, or you want 
+                to run the same command many times.  If you don't know what a raw email looks like, send yourself an email to a Gmail account 
+                and select "Show Original".  The entire text file is the format that the --data option expects 
+                (though it will probably be more complicated and have more headers than you need)
+            </p>
+            <p>
+                On the other hand, if you're trying to do something like use Swaks to send an email copy of a nightly HTML file, 
+                and you want the file to show up correctly in your MUA, Swaks does have a couple of helper options.
+            </p>
+            <p>
+                First, if you want the HTML file to be an attachment that can be openable or savable from your MUA, 
+                you want the --attach option.  For instance, the following command will attach the file report.html.
+                --attach-type is optional, but setting it will help your MUA know what to do with the attachment:
+            </p>
+            <pre><code>
+    swaks --attach-type text/html --attach report.html
+            </code></pre>
+            <p>
+                Another interpretation of this question is "How do I send email which has an HTML-encoded body".
+                This means sending an email that your MUA will display as HTML.  Swaks always treats the "body" portion 
+                of a MIME email as text/plain, so you have to "cheat" and add the MIME headers yourself.  The following should work:
+            </p>
+            <pre><code>
+    swaks --body report.html --add-header "MIME-Version: 1.0" --add-header "Content-Type: text/html"
+            </code></pre>
+            <p>
+                One potential issue with this path is that the contents of report.html won't be encoded as they would if it was processed
+                using --attach.  Whether this will be an issue or not depends on the contents of the file,
+                the mail server(s) used to handle the mail, and the MUA used to view the mail.
+            </p>
+        </div>
+    </div>
+        
+    <div class="row">
+        <div class="two columns">
+            <b><a name="bcc">BCC</a></b>
+        </div>
+        <div class="ten columns">
+            <h5>How do I send a BCC email?</h5>
+            <p>
+                Swaks does not have the --bcc option so many people seem to be asking for lately.
+                It may never get it, as it's not really true to Swaks' core functionality as a transaction tester, versus an MUA.
+                That said, for those who really need this functionality, here's how to do it.
+            </p>
+            <p>First, the reason you don't need a special option to do this:</p>
+            <ol style="padding-left:7%">
+                <li>The envelope-recipients of an email and the contents of the To: and Cc: headers in an email are only related by convention.</li>
+                <li>By default, Swaks places the envelope-recipients (specified by --to) into the To: header.</li>
+                <li>However, as the user of Swaks, you have complete freedom to set the --to option and the To: header independently.</li>
+                <li>Therefore, to "BCC" someone is the same as specifying them in the --to recipients, but specifying a To: header that does not include them.</li>
+            </ol>
+            <p>
+                So, to send a message to aa@example.com and bb@example.com, but only include aa@example.com 
+                in the To: header (or, put another way, to BCC bb@example.com), the following would work:
+            </p>
+            <pre><code>
+    swaks --to aa@example.com,bb@example.com --header "To: aa@example.com"
+            </code></pre>
+        </div>
+    </div>
+    
+    <div class="row">
+        <div class="two columns">
+            <b><a name="support_ipv6">IPv6 Support</a></b>
+        </div>
+        <div class="ten columns">
+            <h5>Does Swaks support IPv6?</h5>
+            <p>Yes, as of release 20120320.0!  Woo!</p>
+        </div>
+    </div>
+</div> <!-- end of content container -->
 
 
-
-
-
-<table cellpadding=3 border=0 width=600>
-<tr>
-<td valign=top><font size=-1><b>Table of Contents</b></font></td>
-<td><font size=-1>
-<ol>
-<li><a href="#mult_recip">How do I use Swaks to send email to multiple recipients?</a>
-<li><a href="#adding_header">How do I add a header?</a>
-<li><a href="#install_macosx">How do I install on Mac OS X?</a>
-<li><a href="#install_windows">How do I install on Windows?</a>
-<li><a href="#send_html_email">How do I send HTML email?</a>
-<li><a href="#bcc">How do I send a BCC email?</a>
-<li><a href="#support_ipv6">Does Swaks support IPv6?</a>
-</ol>
-</font>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b><a name="mult_recip">Multiple Recipients</a></b></font></td>
-<td><font size=-1>
-<B>How do I use Swaks to send email to multiple recipients?</b>
-<P>
-Multiple recipients can be specified by passing them as a single argument to the "--to" option.  Any of the following will result in mail being sent to both foo@example.net and bar@example.com:
-<P>
-Command line:
-<pre>swaks --to foo@example.net,bar@example.com</pre>
-<P>
-Environment variable:
-<pre>SWAKS_OPT_to='foo@example.net,bar@example.com'
-swaks
-</pre>
-<P>
-Config file:
-<pre>
-echo "--to foo@example.net,bar@example.com" >> .swaksrc
-swaks --config .swaksrc
-</pre>
-The argument to the --to option is passed deep into the heart of Swaks with no real validation checking.  This is done intentionally - because Swaks is meant to be a test tool, oddball values should be allowed.  One side effect of this is that including a space after the comma will result in an email address that starts with a comma, which is probably not what you want.
-<P>
-There is one additional consideration here.  Since Swaks is oriented around a single SMTP-session per invocation, it will only ever connect to a single server, even if multiple recipients are specified.  In the example above, both emails will be delivered to the MX server for example.com (since, as documented, the mail routing for the last domain in the list is used).  This may or may not work, depending on the configuration of email server you are testing.
-</font>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b><a name="adding_header">Adding Headers</a></b></font></td>
-<td><font size=-1>
-<B>How do I add a header??</b>
-<P>
-Use the --add-header option:
-<pre>
-swaks --add-header "X-Test-Header: foo"
-</pre>
-<P>
-There are lots more examples in <a href=http://jetmore.org/john/code/swaks/latest/doc/ref.txt>the spec</a>, look for --header and --add-header for details and nuance about each.  A quick rule of thumb though is that you want --header to overwrite a header that already exists in your test email, and you want --add-header to add a completely new header, even if that same header already exists in your test email.
-</font>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b><a name="install_macosx">Install on Mac OS X</a></b></font></td>
-<td><font size=-1>
-<B>How do I install on Mac OS X?</b>
-<P>
-Copy and paste or right-click, save-as works great for me.  If you prefer a package manager, both <a href="http://www.macports.org/">MacPorts</a> and <a href="http://brew.sh/">Homebrew</a> provide Swaks.
-</font>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b><a name="install_windows">Install on Windows</a></b></font></td>
-<td><font size=-1>
-<B>How do I install on Windows?</b>
-<P>
-Swaks has been tested much less on Windows than Mac OS X or Linux (or even Solaris, Swaks' birth-OS), but it has worked when I tested it.  I installed ActiveState Perl, saved the latest version of Swaks as swaks.pl, and used ppm to install Perl modules.  It worked fine for me, but if you are having specific issues let me know.
-</font>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b><a name="send_html_email">HTML Email</a></b></font></td>
-<td><font size=-1>
-<B>How do I send HTML email?</b>
-<P>
-This really depends on what you want to do.  At its base, Swaks is agnostic about what it sends in its DATA section, so you can craft whatever email you want and use it as the DATA of the message using the --data option.  This is the best route for testing, where you usually have a fixed set of test cases to run, or you want to run the same command many times.  If you don't know what a raw email looks like, send yourself an email to a Gmail account and select "Show Original".  The entire text file is the format that the --data option expects (though it will probably be more complicated and have more headers than you need)
-<P>
-On the other hand, if you're trying to do something like use Swaks to send an email copy of a nightly HTML file, and you want the file to show up correctly in your MUA, Swaks does have a couple of helper options.
-<P>
-First, if you want the HTML file to be an attachment that can be openable or savable from your MUA, you want the --attach option.  For instance, the following command will attach the file report.html.  --attach-type is optional, but setting it will help your MUA know what to do with the attachment:
-<P>
-<code>
-swaks --attach-type text/html --attach report.html
-</code>
-<P>
-Another interpretation of this question is "How do I send email which has an HTML-encoded body".  This means sending an email that your MUA will display as HTML.  Swaks always treats the "body" portion of a MIME email as text/plain, so you have to "cheat" and add the MIME headers yourself.  The following should work:
-<P>
-<code>
-swaks --body report.html --add-header "MIME-Version: 1.0" --add-header "Content-Type: text/html"
-</code>
-<P>
-One potential issue with this path is that the contents of report.html won't be encoded as they would if it was processed using --attach.  Whether this will be an issue or not depends on the contents of the file, the mail server(s) used to handle the mail, and the MUA used to view the mail
-</font>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b><a name="bcc">BCC</a></b></font></td>
-<td><font size=-1>
-<B>How do I send a BCC email?</b>
-<P>
-Swaks does not have the --bcc option so many people seem to be asking for lately.  It may never get it, as it's not really true to Swaks' core functionality as a transaction tester, versus an MUA.  That said, for those who really need this functionality, here's how to do it.
-<P>
-First, the reason you don't need a special option to do this:
-<P>
-<ol>
-<li>The envelope-recipients of an email and the contents of the To: and Cc: headers in an email are only related by convention.</li>
-<li>By default, Swaks places the envelope-recipients (specified by --to) into the To: header.</li>
-<li>However, as the user of Swaks, you have complete freedom to set the --to option and the To: header independently.</li>
-<li>Therefore, to "BCC" someone is the same as specifying them in the --to recipients, but specifying a To: header that does not include them.</li>
-</ol>
-<P>
-So, to send a message to aa@example.com and bb@example.com, but only include aa@example.com in the To: header (or, put another way, to BCC bb@example.com), the following would work:
-<P>
-<code>
-swaks --to aa@example.com,bb@example.com --header "To: aa@example.com"
-</code>
-</font>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b><a name="support_ipv6">IPv6 Support</a></b></font></td>
-<td><font size=-1>
-<B>Does Swaks support IPv6?</b>
-<P>
-Yes, as of release 20120320.0!  Woo!
-</font>
-</td></tr>
-<!-- y8y
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b><a name="">Multiple Recipients</a></b></font></td>
-<td><font size=-1>
-<B>How do I use Swaks to send email to multiple recipients?</b>
-<P>
-</font>
-</td></tr>
--->
 <!-- TODO
 
 These are all the remaining Q-strings from 2011 through 9/16
@@ -233,5 +285,6 @@ swaks+Host+did+not+advertise+authentication
 20120227: swaksrc%20configuration%20file%20example%20swaks
 	- should include a swaksrc and a sh snippet showing basic config changes with docs
 -->
-</table>
-</td></tr></table></body></html>
+
+</body>
+</html>

--- a/doc/faq.html
+++ b/doc/faq.html
@@ -12,9 +12,15 @@
         a:link { color: blue }
         a:visited { color: blue }
         a:active { color: navy }
+        code { font-size: 120% }
+        pre, code {
+            overflow-x: auto;
+            overflow-y: hidden; 
+            white-space: nowrap;
+        }
+        .container { max-width: 600px }
         .header { margin-top: 3% }
         .footer { margin-bottom: 3% }
-        code { font-size: 120% }
     </style>
 </head>
 <body>
@@ -22,7 +28,7 @@
 <div class="section header">
     <div class="container">
         <div class="row">
-            <a name=swaks><h1>Swaks - Swiss Army Knife for SMTP</h1></a>
+            <a name="swaks"><h1><b>Swaks</b> - Swiss Army Knife for SMTP</h1></a>
             <span id="subheader">A scriptable, transaction-oriented SMTP test tool</span>
         </div>
         <hr/>
@@ -34,7 +40,7 @@
         <h4>Occasionally Asked Questions</h4>
         <p>
             These are questions that I occasionally get asked or I see pop up in a Google query string.<br/>
-            If you are trying to figure out something using Swaks, drop me a line at <a href=mailto:proj-swaks@jetmore.net>proj-swaks@jetmore.net</a>.  Swaks is a low-traffic project and I enjoy making it better, whether it's docs or code or just giving a hint in an email.
+            If you are trying to figure out something using Swaks, drop me a line at <a href="mailto:proj-swaks@jetmore.net">proj-swaks@jetmore.net</a>.  Swaks is a low-traffic project and I enjoy making it better, whether it's docs or code or just giving a hint in an email.
         </p>
         <p><a href="./index.html">return to main page</a></p>
     </div>
@@ -70,21 +76,21 @@
             <p>
                 Command line:
                 <pre><code>
-    swaks --to foo@example.net,bar@example.com
+swaks --to foo@example.net,bar@example.com
                 </code></pre>
             </p>
             <p>
                 Environment variable:
                 <pre><code>
-    SWAKS_OPT_to='foo@example.net,bar@example.com'
-    swaks
+SWAKS_OPT_to='foo@example.net,bar@example.com'
+swaks
                 </code></pre>
             </p>
             <p>
                 Config file:
                 <pre><code>
-    echo "--to foo@example.net,bar@example.com" >> .swaksrc
-    swaks --config .swaksrc
+echo "--to foo@example.net,bar@example.com" >> .swaksrc
+swaks --config .swaksrc
                 </code></pre>
             </pre>
             <p>
@@ -111,10 +117,10 @@
             <h5>How do I add a header?</h5>
             <p>Use the --add-header option:</p>
             <pre><code>
-    swaks --add-header "X-Test-Header: foo"
+swaks --add-header "X-Test-Header: foo"
             </code></pre>
             <p>
-                There are lots more examples in <a href=http://jetmore.org/john/code/swaks/latest/doc/ref.txt>the spec</a>, 
+                There are lots more examples in <a href="http://jetmore.org/john/code/swaks/latest/doc/ref.txt">the spec</a>, 
                 look for --header and --add-header for details and nuance about each.  
                 A quick rule of thumb though is that you want --header to overwrite a header that already exists in your test email, 
                 and you want --add-header to add a completely new header, even if that same header already exists in your test email.
@@ -173,7 +179,7 @@
                 --attach-type is optional, but setting it will help your MUA know what to do with the attachment:
             </p>
             <pre><code>
-    swaks --attach-type text/html --attach report.html
+swaks --attach-type text/html --attach report.html
             </code></pre>
             <p>
                 Another interpretation of this question is "How do I send email which has an HTML-encoded body".
@@ -181,7 +187,7 @@
                 of a MIME email as text/plain, so you have to "cheat" and add the MIME headers yourself.  The following should work:
             </p>
             <pre><code>
-    swaks --body report.html --add-header "MIME-Version: 1.0" --add-header "Content-Type: text/html"
+swaks --body report.html --add-header "MIME-Version: 1.0" --add-header "Content-Type: text/html"
             </code></pre>
             <p>
                 One potential issue with this path is that the contents of report.html won't be encoded as they would if it was processed
@@ -214,7 +220,7 @@
                 in the To: header (or, put another way, to BCC bb@example.com), the following would work:
             </p>
             <pre><code>
-    swaks --to aa@example.com,bb@example.com --header "To: aa@example.com"
+swaks --to aa@example.com,bb@example.com --header "To: aa@example.com"
             </code></pre>
         </div>
     </div>

--- a/doc/index.html
+++ b/doc/index.html
@@ -12,6 +12,7 @@
         a:link { color: blue }
         a:visited { color: blue }
         a:active { color: navy }
+        .container { max-width: 600px }
         .header { margin-top: 3% }
         .footer { margin-bottom: 3% }
     </style>
@@ -21,7 +22,7 @@
 <div class="section header">
     <div class="container">
         <div class="row">
-            <a name="swaks"><h1>Swaks - Swiss Army Knife for SMTP</h1></a>
+            <a name="swaks"><h1><b>Swaks</b> - Swiss Army Knife for SMTP</h1></a>
             <!--
             <span id="subheader">A scriptable, transaction-oriented SMTP test tool</span>
             -->

--- a/doc/index.html
+++ b/doc/index.html
@@ -1,88 +1,119 @@
-<html><head><title>Swaks - Swiss Army Knife for SMTP</title>
-<style type="text/css">
-a:link { color: blue }
-a:visited { color: blue }
-a:active { color: navy }
-body {
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 13px;
-    font-style: normal;
-    font-variant: normal;
-    font-weight: normal;
-    line-height: 1.7em;
-}
-</style>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Swaks - Swiss Army Knife for SMTP</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/skeleton/2.0.4/skeleton.min.css" /> <!-- https://cdnjs.com/libraries/skeleton -->
+    <style type="text/css">
+        body { font-family: "Helvetica Neue", Helvetica, Arial, sans-serif }
+        #subheader { font-size: 120% }
+        #rss { font-size: 70% }
+        a:link { color: blue }
+        a:visited { color: blue }
+        a:active { color: navy }
+        .header { margin-top: 3% }
+        .footer { margin-bottom: 3% }
+    </style>
 </head>
 <body>
-<table width=100% height=100%><tr><td valign=middle align=center>
-<table cellpadding=3 border=0 width=600>
-<tr><td align=center>
-<a name=swaks>
-<font size=+3><B>Swaks</B> - Swiss Army Knife for SMTP</font>
-</a>
-<!--
-<br>
-<font size=-1>A scriptable, transaction-oriented SMTP test tool</font>
--->
-</td></tr><tr><td>
-<P><hr><P>
-<!--
-<tr><td><hr></td></tr>
-<tr><td align=center>
-<a href=index.html>Main</a> :: <a href=about.html>About</a> :: <a href=download.html>Download</a> :: <a href=docs.html>Documentation</a> :: <a href=contact.html>Interact</a>
-</td></tr>
--->
-<font size=+1><B>About</B></font>
-<P>
-Swaks is a featureful, flexible, scriptable, transaction-oriented SMTP test tool written and maintained by <a href=https://www.jetmore.org/john/>John Jetmore</a>.  It is free to use and <a href=latest/LICENSE.txt>licensed</a> under the GNU GPLv2.  Features include:
-<ul>
-<li><font size=-1>SMTP extensions including TLS, authentication, pipelining, PROXY, PRDR, and XCLIENT</font></li>
-<li><font size=-1>Protocols including SMTP, ESMTP, and LMTP</font></li>
-<li><font size=-1>Transports including UNIX-domain sockets, internet-domain sockets (IPv4 and IPv6), and pipes to spawned processes</font></li>
-<li><font size=-1>Completely scriptable configuration, with option specification via environment variables, configuration files, and command line</font></li>
-</ul>
-<P><hr><P>
-<font size=+1><B>Download</B></font>
-<P>
-The latest version of Swaks is <b>20190914.0</b>, which can be downloaded as a <a href=files/swaks-20190914.0.tar.gz>package</a> or a <a href=files/swaks-20190914.0/swaks>standalone script</a>.
-<P>
-There is also a <a href=versions.html>versions page</a> which lists every released version of Swaks, complete with changelogs and download links.
-<P><hr><P>
-<font size=+1><B>Documentation</B></font>
-<P>
-The <a href=latest/doc/ref.txt>reference documentation</a> from the latest release, which includes quick-start examples, is available.  There is also an <a href=faq.html>Occasionally Asked Questions</a> document.
-<P><hr><P>
-<font size=+1><B>Source</B></font>
-<P>
-The Swaks source code is available at <a href=https://github.com/jetmore/swaks>https://github.com/jetmore/swaks</a>.
-<P><hr><P>
-<font size=+1><B>News</B></font> <font size=-1>(<a href=https://www.jetmore.org/john/blog/c/swaks/feed/>rss</a>)</font>
-<P>
-<font size=-1>
-<ul>
-<li>2019-09-14 - <a href="https://www.jetmore.org/john/blog/2019/09/swaks-release-20190914-0-available/">Swaks Release 20190914.0 Available</a></li>
-<li>2018-11-04 - <a href="https://www.jetmore.org/john/blog/2018/11/swaks-release-20181104-0-available/">Swaks Release 20181104.0 Available</a></li>
-<li>2017-01-01 - <a href="https://www.jetmore.org/john/blog/2017/01/swaks-release-20170101-0-available/">Swaks Release 20170101.0 Available</a></li>
-<li>2013-02-09 - <a href="https://www.jetmore.org/john/blog/2013/02/swaks-release-20130209-0-available/">Swaks Release 20130209.0 Available</a></li>
-<li>2012-03-20 - <a href="https://www.jetmore.org/john/blog/2012/03/swaks-release-20120320-0-available/">Swaks Release 20120320.0 Available</a></li>
-</ul>
-</font>
-<P><hr><P>
-<font size=+1><B>Communications</B></font>
-<P>
-<font size=-1>
-<ul>
-<li><a href=mailto:updates-swaks@jetmore.net>Send a mail</a> to receive email when new versions are released</li>
-<li><a href='https://twitter.com/SwaksSMTP'>Follow @SwaksSMTP</a> on twitter</li>
-<li><a href='mailto:proj-swaks@jetmore.net'>Contact the author</a> - suggestion, tips, patches, feedback, critiques always welcome</li>
-<li><a href=https://www.jetmore.org/john/blog/c/swaks/>Blog</a> - Swaks-specific blog category (same feed as News section above)</li>
-<li><a href=https://github.com/jetmore/swaks/issues>Issues</a> - Open an issue for feature requests and bugs</li>
-</ul>
-</td></tr>
 
-<tr><td><hr></td></tr>
-<tr><td align=center>
-<font size=-2><a href=/john/>www.jetmore.org/john</a>/<a href=/john/code/>code</a></font>/<font size=+1>swaks</font>
-</td></tr>
-</table>
-</td></tr></table></body></html>
+<div class="section header">
+    <div class="container">
+        <div class="row">
+            <a name="swaks"><h1>Swaks - Swiss Army Knife for SMTP</h1></a>
+            <!--
+            <span id="subheader">A scriptable, transaction-oriented SMTP test tool</span>
+            -->
+        </div>
+        <hr/>
+    </div>
+</div>
+
+<div class="container">
+    <div class="row">
+        <!--
+        <p>
+        <a href="index.html">Main</a> :: 
+        <a href="about.html">About</a> :: 
+        <a href="download.html">Download</a> :: 
+        <a href="docs.html">Documentation</a> :: 
+        <a href="contact.html">Interact</a>
+        </p>
+        -->
+    </div>
+
+    <div class="row">
+        <h4>About</h4>
+        <p>
+            Swaks is a featureful, flexible, scriptable, transaction-oriented SMTP test tool written 
+            and maintained by <a href="https://www.jetmore.org/john/">John Jetmore</a>.  
+            It is free to use and <a href="latest/LICENSE.txt">licensed</a> under the GNU GPLv2.
+        </p>
+        <p><b>Features include:</b></p>
+        <ul>
+            <li>SMTP extensions including TLS, authentication, pipelining, PROXY, PRDR, and XCLIENT</li>
+            <li>Protocols including SMTP, ESMTP, and LMTP</li>
+            <li>Transports including UNIX-domain sockets, internet-domain sockets (IPv4 and IPv6), and pipes to spawned processes</li>
+            <li>Completely scriptable configuration, with option specification via environment variables, configuration files, and command line</li>
+        </ul>
+    </div>
+
+    <hr/>
+
+    <div class="row">
+        <h4>Download</h4>
+        <p>
+            The latest version of Swaks is <b>20190914.0</b>, which can be downloaded as a <a href="files/swaks-20190914.0.tar.gz">package</a> or a <a href="files/swaks-20190914.0/swaks">standalone script</a>.<br/>
+            There is also a <a href="versions.html">versions page</a> which lists every released version of Swaks, complete with changelogs and download links.
+        </p>
+    </div>
+
+    <div class="row">
+        <h4>Documentation</h4>
+        <p>
+            The <a href="latest/doc/ref.txt">reference documentation</a> from the latest release, 
+            which includes quick-start examples, is available.  
+            There is also an <a href="faq.html">Occasionally Asked Questions</a> document.
+        </p>
+    </div>
+
+    <div class="row">
+        <h4>Source</h4>
+        <p>The Swaks source code is available at <a href="https://github.com/jetmore/swaks">https://github.com/jetmore/swaks</a>.</p>
+    </div>
+
+    <div class="row">
+        <h4>News <span id="rss">(<a href="https://www.jetmore.org/john/blog/c/swaks/feed/">rss</a>)</span></h4>
+        <ul>
+            <li>2019-09-14 - <a href="https://www.jetmore.org/john/blog/2019/09/swaks-release-20190914-0-available/">Swaks Release 20190914.0 Available</a></li>
+            <li>2018-11-04 - <a href="https://www.jetmore.org/john/blog/2018/11/swaks-release-20181104-0-available/">Swaks Release 20181104.0 Available</a></li>
+            <li>2017-01-01 - <a href="https://www.jetmore.org/john/blog/2017/01/swaks-release-20170101-0-available/">Swaks Release 20170101.0 Available</a></li>
+            <li>2013-02-09 - <a href="https://www.jetmore.org/john/blog/2013/02/swaks-release-20130209-0-available/">Swaks Release 20130209.0 Available</a></li>
+            <li>2012-03-20 - <a href="https://www.jetmore.org/john/blog/2012/03/swaks-release-20120320-0-available/">Swaks Release 20120320.0 Available</a></li>
+        </ul>
+    </div>
+
+    <div class="row">
+        <h4>Communications</h4>
+        <ul>
+            <li><a href="mailto:updates-swaks@jetmore.net">Send a mail</a> to receive email when new versions are released</li>
+            <li><a href="https://twitter.com/SwaksSMTP">Follow @SwaksSMTP</a> on twitter</li>
+            <li><a href="mailto:proj-swaks@jetmore.net">Contact the author</a> - suggestion, tips, patches, feedback, critiques always welcome</li>
+            <li><a href="https://www.jetmore.org/john/blog/c/swaks/">Blog</a> - Swaks-specific blog category (same feed as News section above)</li>
+            <li><a href="https://github.com/jetmore/swaks/issues">Issues</a> - Open an issue for feature requests and bugs</li>
+        </ul>
+    </div>
+</div> <!-- end of content container -->
+
+<div class="section footer">
+    <div class="container">
+        <div class="row">
+            <hr/>
+            <p><a href="/john/">www.jetmore.org/john</a> / <a href="/john/code/">code</a> / <b>swaks</b></p>
+        </div>
+    </div>
+</div>
+
+</body>
+</html>

--- a/doc/versions.html
+++ b/doc/versions.html
@@ -12,9 +12,16 @@
         a:link { color: blue }
         a:visited { color: blue }
         a:active { color: navy }
+        pre { overflow-y: scroll }
+        code { font-size: 110% }
+        pre, code {
+            overflow-x: auto;
+            overflow-y: hidden; 
+            white-space: nowrap;
+        }
+        .container { max-width: 600px }
         .header { margin-top: 3% }
         .footer { margin-bottom: 3% }
-        code { font-size: 110% }
     </style>
 </head>
 <body>
@@ -22,7 +29,7 @@
 <div class="section header">
     <div class="container">
         <div class="row">
-            <a name="swaks"><h1>Swaks - Swiss Army Knife for SMTP</h1></a>
+            <a name="swaks"><h1><b>Swaks</b> - Swiss Army Knife for SMTP</h1></a>
             <span id="subheader">A scriptable, transaction-oriented SMTP test tool</span>
         </div>
         <hr/>

--- a/doc/versions.html
+++ b/doc/versions.html
@@ -1,53 +1,71 @@
-<html><head><title>Swaks - Swiss Army Knife for SMTP</title>
-<style type="text/css">
-a:link { color: blue }
-a:visited { color: blue }
-a:active { color: navy }
-body {
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 13px;
-    font-style: normal;
-    font-variant: normal;
-    font-weight: normal;
-    line-height: 1.7em;
-}
-</style>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Swaks - Swiss Army Knife for SMTP</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/skeleton/2.0.4/skeleton.min.css" /> <!-- https://cdnjs.com/libraries/skeleton -->
+    <style type="text/css">
+        body { font-family: "Helvetica Neue", Helvetica, Arial, sans-serif }
+        #subheader { font-size: 120% }
+        #rss { font-size: 70% }
+        a:link { color: blue }
+        a:visited { color: blue }
+        a:active { color: navy }
+        .header { margin-top: 3% }
+        .footer { margin-bottom: 3% }
+        code { font-size: 110% }
+    </style>
 </head>
 <body>
-<table width=100% height=100%><tr><td valign=middle align=center>
-<table cellpadding=3 border=0 width=600>
-<tr><td align=center>
-<a name=swaks>
-<font size=+3><B>Swaks</B> - Swiss Army Knife for SMTP</font>
-</a>
-<br>
-<font size=-1>A scriptable, transaction-oriented SMTP test tool</font>
-</td></tr><tr><td>
-<P><hr><P>
-<!--
-<tr><td><hr></td></tr>
-<tr><td align=center>
-<a href=index.html>Main</a> :: <a href=about.html>About</a> :: <a href=download.html>Download</a> :: <a href=docs.html>Documentation</a> :: <a href=contact.html>Interact</a>
-</td></tr>
--->
-<font size=+1><B>Versions</B></font>
-<P>
-This page lists every official release of Swaks, from newest to oldest.  All releases include that version's Changes, and newer releases also include a change summary.
-<P>
-<a href=index.html>return to main page</a>
-<P><hr><P>
-</tr></td></table>
 
+<div class="section header">
+    <div class="container">
+        <div class="row">
+            <a name="swaks"><h1>Swaks - Swiss Army Knife for SMTP</h1></a>
+            <span id="subheader">A scriptable, transaction-oriented SMTP test tool</span>
+        </div>
+        <hr/>
+    </div>
+</div>
 
+<div class="container">
+    <div class="row">
+        <!--
+        <p>
+        <a href="index.html">Main</a> :: 
+        <a href="about.html">About</a> :: 
+        <a href="download.html">Download</a> :: 
+        <a href="docs.html">Documentation</a> :: 
+        <a href="contact.html">Interact</a>
+        </p>
+        -->
+    </div>
+    <div class="row">
+        <b>Versions</b>
+        <p>
+          This page lists every official release of Swaks, from newest to oldest.  All releases include that version's Changes, 
+          and newer releases also include a change summary.
+        </p>
+        <p><a href="./index.html">return to main page</a></p>
+    </div>
+    <hr/>
 
-<table cellpadding=3 border=0 width=600>
-<tr>
-<td valign=top><font size=-1><b>20190914.0</b></font></td>
-<td><font size=-1>
-<B>Links:</b> <a href=files/swaks-20190914.0.tar.gz>Distribution</a>, <a href=files/swaks-20190914.0/swaks>script only</a>, <a href=files/swaks-20190914.0/doc/ref.txt>version docs</a>
-<P>
-<B>Change Summary:</B><BR>
-<pre>
+    <div class="row">
+        <div class="two columns">
+            <b>20190914.0</b>
+        </div>
+        <div class="ten columns">
+            <p>
+                <b>Links:</b>
+                <a href="./files/swaks-20190914.0.tar.gz">distribution</a>,
+                <a href="./files/swaks-20190914.0/swaks"">script only</a>,
+                <a href="./files/swaks-20190914.0/doc/ref.txt">version docs</a>
+            </p>
+            <p>
+                <b>Change Summary:</b>
+            </p>
+            <pre><code>
 New Features:
   * Source is now available on github.com/jetmore/swaks
   * Added --body-attach option to allow more granularity in setting body
@@ -78,9 +96,11 @@ Notable Bugs Fixed:
   * -S is now a distinct option from -s, as documented
   * Fix bug preventing the --option=arg option format from being
     unusable with --header and --attach* options
-</pre>
-<B>Changelog:</B><BR>
-<pre>
+            </code></pre>
+            <p>
+                <b>Changelog:</b>
+            </p>
+            <pre><code>
 * 20181110 --add-header documentation was still referencing a single-char,
            no longer valid, replacement token. Replace with the correct token.
 * 20181110 Doc fix for default body - %SWAKS_VERSION% missing trailing char.
@@ -152,16 +172,25 @@ Notable Bugs Fixed:
 * 20190817 Remove re-prompting for port when an invalid service name was
            supplied. Just error and exit instead
 > 20190914 released 20190914.0
-</pre>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b>v20181104.0</b></font></td>
-<td><font size=-1>
-<B>Links:</b> <a href=files/swaks-20181104.0.tar.gz>Distribution</a>, <a href=files/swaks-20181104.0/swaks>script only</a>, <a href=files/swaks-20181104.0/doc/ref.txt>version docs</a>
-<P>
-<B>Change Summary:</B><BR>
-<pre>
+            </code></pre>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="two columns">
+            <b>v20181104.0</b>
+        </div>
+        <div class="ten columns">
+            <p>
+                <b>Links:</b>
+                <a href="./files/swaks-20181104.0.tar.gz">distribution</a>,
+                <a href="./files/swaks-20181104.0/swaks"">script only</a>,
+                <a href="./files/swaks-20181104.0/doc/ref.txt">version docs</a>
+            </p>
+            <p>
+                <b>Change Summary:</b>
+            </p>
+            <pre><code>
 New Features:
   * Added --dump-mail option.
   * Added --xclient-delim, --xclient-destaddr, --xclient-destport,
@@ -185,9 +214,11 @@ Notable Bugs Fixed:
   * Fixed two bugs which prevented interactions between --dump,
     --auth-hide-password, --dump-as-body, and --dump-as-body-shows-password
     from producing consistent output.
-</pre>
-<B>Changelog:</B><BR>
-<pre>
+            </code></pre>
+            <p>
+                <b>Changelog:</b>
+            </p>
+            <pre><code>
 * 20170106 Fix typos in base.pod (reported by Andreas Metzler/Debian)
 * 20170307 Fix spelling, grammar, and phrasing issues in base.pod, faq.html,
            and index.html
@@ -256,16 +287,25 @@ Notable Bugs Fixed:
 * 20181104 Rename LICENSE and README to have .txt extension
 * 20181104 Update release tooling after development environment changes
 > 20181104 released 20181104.0
-</pre>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b>v20170101.0</b></font></td>
-<td><font size=-1>
-<B>Links:</b> <a href=files/swaks-20170101.0.tar.gz>Distribution</a>, <a href=files/swaks-20170101.0/swaks>script only</a>, <a href=files/swaks-20170101.0/doc/ref.txt>version docs</a>
-<P>
-<B>Change Summary:</B><BR>
-<pre>
+            </code></pre>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="two columns">
+            <b>v20170101.0</b>
+        </div>
+        <div class="ten columns">
+            <p>
+                <b>Links:</b>
+                <a href="./files/swaks-20170101.0.tar.gz">distribution</a>,
+                <a href="./files/swaks-20170101.0/swaks"">script only</a>,
+                <a href="./files/swaks-20170101.0/doc/ref.txt">version docs</a>
+            </p>
+            <p>
+                <b>Change Summary:</b>
+            </p>
+            <pre><code>
 New Features:
   * Added Per-Recipient Data Response (PRDR) support
     (see https://tools.ietf.org/html/draft-hall-prdr-00).
@@ -278,9 +318,11 @@ Notable Changes:
   * Default DATA template now includes a Message-Id: header.
 Notable Bugs Fixed:
   * Fixed incorrect range on XCLIENT rfc1891/xtext encoding.
-</pre>
-<B>Changelog:</B><BR>
-<pre>
+            </code></pre>
+            <p>
+                <b>Changelog:</b>
+            </p>
+            <pre><code>
 * 20130422 Fixed typo in man page ("test" -> "text"), reported by
            Graeme Hewson.
 * 20130906 Fixed some POD formatting errors. Exit code formatting reported by
@@ -311,16 +353,25 @@ Notable Bugs Fixed:
 * 20170101 Removed some cruft from do_smtp_gen (noticed by accident)
 * 20170101 Removed unneeded extra functionality added to transact() for
            PRDR implementation (functionality already existed)
-</pre>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b>v20130209.0</b></font></td>
-<td><font size=-1>
-<B>Links:</b> <a href=files/swaks-20130209.0.tar.gz>Distribution</a>, <a href=files/swaks-20130209.0/swaks>script only</a>, <a href=files/swaks-20130209.0/doc/ref.txt>version docs</a>
-<P>
-<B>Change Summary:</B><BR>
-<pre>
+            </code></pre>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="two columns">
+            <b>v20130209.0</b>
+        </div>
+        <div class="ten columns">
+            <p>
+                <b>Links:</b>
+                <a href="./files/swaks-20130209.0.tar.gz">distribution</a>,
+                <a href="./files/swaks-20130209.0/swaks"">script only</a>,
+                <a href="./files/swaks-20130209.0/doc/ref.txt">version docs</a>
+            </p>
+            <p>
+                <b>Change Summary:</b>
+            </p>
+            <pre><code>
 New Features:
   * Support for the XCLIENT SMTP extension
     (see http://www.postfix.org/XCLIENT_README.html)
@@ -356,9 +407,11 @@ Notable Bugs Fixed
   * Swaks could fail to handle the end of a TLS session over a pipe transport
     when the server has closed the connection but Swaks is expecting to read
     more data
-</pre>
-<B>Changelog:</B><BR>
-<pre>
+            </code></pre>
+            <p>
+                <b>Changelog:</b>
+            </p>
+            <pre><code>
 * 20120330 add --tls-get-peer-cert to --dump output
 * 20120330 add --tls-cert and --tls-key options to allow swaks to use
            certs for its half of the session.  debian bug 497654,
@@ -429,16 +482,25 @@ Notable Bugs Fixed
            the server returns an improper rspauth.  swaks would understand
            that auth failed, but later than it should have (reported by
            Erwan Legrand)
-</pre>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b>v20120320.0</b></font></td>
-<td><font size=-1>
-<B>Links:</b> <a href=files/swaks-20120320.0.tar.gz>Distribution</a>, <a href=files/swaks-20120320.0/swaks>script only</a>, <a href=files/swaks-20120320.0/doc/ref.txt>version docs</a>
-<P>
-<B>Change Summary:</B><BR>
-<pre>
+            </code></pre>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="two columns">
+            <b>v20120320.0</b>
+        </div>
+        <div class="ten columns">
+            <p>
+                <b>Links:</b>
+                <a href="./files/swaks-20120320.0.tar.gz">distribution</a>,
+                <a href="./files/swaks-20120320.0/swaks"">script only</a>,
+                <a href="./files/swaks-20120320.0/doc/ref.txt">version docs</a>
+            </p>
+            <p>
+                <b>Change Summary:</b>
+            </p>
+            <pre><code>
 New Features:
   * IPv6 support
   * -4 and -6 options to force IPv4 or IPv6.
@@ -461,9 +523,11 @@ Notable Bugs Fixed
     success response, or a plaintext failure.  Previously in that
     situation swaks did not handle the case of the plaintext error and
     the --auth-plaintext option well, resulting in confusing output.
-</pre>
-<B>Changelog:</B><BR>
-<pre>
+            </code></pre>
+            <p>
+                <b>Changelog:</b>
+            </p>
+            <pre><code>
 * 20120101 typo fix in docs (rep. Andreas Metzler)
 * 20120101 changed the indent formatting so all the examples are at a
            consistent indent.
@@ -508,16 +572,25 @@ Notable Bugs Fixed
            noted that plaintext passwords can be shown i --dump output.
 * 20120320 Small patch to handle (-6 not set, --server IPv6, ipv6 not
            available) gracefully. Report from and patch by Ulrich Zehl.
-</pre>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b>v20111230.0</b></font></td>
-<td><font size=-1>
-<B>Links:</b> <a href=files/swaks-20111230.0.tar.gz>Distribution</a>, <a href=files/swaks-20111230.0/swaks>script only</a>, <a href=files/swaks-20111230.0/doc/ref.txt>version docs</a>
-<P>
-<B>Change Summary:</B><BR>
-<pre>
+            </code></pre>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="two columns">
+            <b>v20111230.0</b>
+        </div>
+        <div class="ten columns">
+            <p>
+                <b>Links:</b>
+                <a href="./files/swaks-20111230.0.tar.gz">distribution</a>,
+                <a href="./files/swaks-20111230.0/swaks"">script only</a>,
+                <a href="./files/swaks-20111230.0/doc/ref.txt">version docs</a>
+            </p>
+            <p>
+                <b>Change Summary:</b>
+            </p>
+            <pre><code>
 New Features:
   * Added --output-file family of options to capture some or all output
     without requiring shell redirection
@@ -557,9 +630,11 @@ Notable Bugs Fixed
   * Previous release contained a regression in which TLS responses sent in
     multiple packets were not processed correctly.
     (reported by Peter J. Holzer)
-</pre>
-<B>Changelog:</B><BR>
-<pre>
+            </code></pre>
+            <p>
+                <b>Changelog:</b>
+            </p>
+            <pre><code>
 * 20100212 fixed doc typo
 * 20100215 added recipes.pod to repo and added vrfy and fswaks recipes
 * 20101217 added and documented the --output-file* options
@@ -636,16 +711,25 @@ Notable Bugs Fixed
 * 20111229 Change indent from 2-space to 1-tab, use 120-char width where it
            makes sense.
 * 20111229 address some -w output related to the DIGEST-MD5 rewrite
-</pre>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b>v20100211.0</b></font></td>
-<td><font size=-1>
-<B>Links:</b> <a href=files/swaks-20100211.0.tar.gz>Distribution</a>, <a href=files/swaks-20100211.0/swaks>script only</a>, <a href=files/swaks-20100211.0/doc/ref.txt>version docs</a>
-<P>
-<B>Change Summary:</B><BR>
-<pre>
+            </code></pre>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="two columns">
+            <b>v20100211.0</b>
+        </div>
+        <div class="ten columns">
+            <p>
+                <b>Links:</b>
+                <a href="./files/swaks-20100211.0.tar.gz">distribution</a>,
+                <a href="./files/swaks-20100211.0/swaks"">script only</a>,
+                <a href="./files/swaks-20100211.0/doc/ref.txt">version docs</a>
+            </p>
+            <p>
+                <b>Change Summary:</b>
+            </p>
+            <pre><code>
 * Completely rewritten documentation.  Designed to sort options by
   broad category to make finding options easier
 * New configuration system.  Allow default .swaksrc, custom config
@@ -659,9 +743,11 @@ Notable Bugs Fixed
 * New option --tls-get-peer-cert
 * New option --attach-name
 * Many bugs fixes and other minor tweaks
-</pre>
-<B>Changelog:</B><BR>
-<pre>
+            </code></pre>
+            <p>
+                <b>Changelog:</b>
+            </p>
+            <pre><code>
 * 20061227 20061218 in --h-Header construct, allow trailing colon and
            allow single dash in addition to double (previously a colon
            in the arg name resulted in double colon in header and
@@ -767,13 +853,23 @@ Notable Bugs Fixed
 * 20100211 fixed interaction bug between POD/__END__/&DATA
 * 20100211 working on release engineering
 * 20100211 moved to swaks.org, redid website
-</pre>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b>v<a href=files/swaks-20061116.0>20061116.0</a></b></font></td>
-<td><font size=-1>
-<pre>
+            </code></pre>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="two columns">
+            <b>20061116.0</b>
+        </div>
+        <div class="ten columns">
+            <p>
+                <b>Links:</b>
+                <a href="./files/swaks-20061116.0">script only</a>
+            </p>
+            <p>
+                <b>Changelog:</b>
+            </p>
+            <pre><code>
 * 20060622 Updated FSF address in GPL notice
 * 20060623 added url to CONTACT section of docs
 * 20060718 20050625 added --protocol option.  'esmtp' is default with
@@ -841,13 +937,23 @@ Notable Bugs Fixed
 * 20061115 documented rfc3848 --protocol options and behaviours
 * 20061115 20060806 fixed bug where From: was prompted for on some -q
            types that don't require it, too (Helo: too)
-</pre>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b>v<a href=files/swaks-20060621.0>20060621.0</a></b></font></td>
-<td><font size=-1>
-<pre>
+            </code></pre>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="two columns">
+            <b>20060621.0</b>
+        </div>
+        <div class="ten columns">
+            <p>
+                <b>Links:</b>
+                <a href="./files/swaks-20060621.0">script only</a>
+            </p>
+            <p>
+                <b>Changelog:</b>
+            </p>
+            <pre><code>
 * 20060121 updated copyright to 2006
 * 20060121 fiddled w/ --dump output, trying to get every possible
            option displayed (for test suite)
@@ -903,25 +1009,45 @@ Notable Bugs Fixed
 * 20060526 added and document --add-header option (debian bug 366317)
 * 20060621 added comments to top of code about viewing docs
 * 20060621 added note at top and in docs about update email address
-</pre>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b>v<a href=files/swaks-20050709.1>20050709.1</a></b></font></td>
-<td><font size=-1>
-<pre>
+            </code></pre>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="two columns">
+            <b>20050709.1</b>
+        </div>
+        <div class="ten columns">
+            <p>
+                <b>Links:</b>
+                <a href="./files/swaks-20050709.1">script only</a>
+            </p>
+            <p>
+                <b>Changelog:</b>
+            </p>
+            <pre><code>
 * 20050629 fixed bug where latent $@ errors caused socket connections
            to seem to fail (run --socket on a server w/o Net::DNS)
 * 20050709 fixed bug where TLS multiline responses were broken if
            sent in multiple packets (reported by
            charlieb.budge.apana.org.au)
-</pre>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b>v<a href=files/swaks-20050625.8>20050625.8</a></b></font></td>
-<td><font size=-1>
-<pre>
+            </code></pre>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="two columns">
+            <b>20050625.8</b>
+        </div>
+        <div class="ten columns">
+            <p>
+                <b>Links:</b>
+                <a href="./files/swaks-20050625.8">script only</a>
+            </p>
+            <p>
+                <b>Changelog:</b>
+            </p>
+            <pre><code>
 * 20050625 fixed bug in do_smtp_tls where it ignored timeout on
            on STARTTLS call
 * 20050625 fixed bug where <> not correctly handled for user/pass
@@ -940,13 +1066,23 @@ Notable Bugs Fixed
            either -a not also used or some arg not supplied)
 * 20050625 20050605 added --socket option to allow smtp over
            unix domain socket
-</pre>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b>v<a href=files/swaks-20050605.3>20050605.3</a></b></font></td>
-<td><font size=-1>
-<pre>
+            </code></pre>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="two columns">
+            <b>20050605.3</b>
+        </div>
+        <div class="ten columns">
+            <p>
+                <b>Links:</b>
+                <a href="./files/swaks-20050605.3">script only</a>
+            </p>
+            <p>
+                <b>Changelog:</b>
+            </p>
+            <pre><code>
 * 20050605 updated copyright dates
 * 20050605 20050510 added OS test on getpwuid to allow running on
            Win32, spent some time evaluating capabilities (reported
@@ -954,25 +1090,45 @@ Notable Bugs Fixed
 * 20050605 added portability section to documentation
 * 20060605 20040909 the line ending translation was very slow for
            large files.  fixed.
-</pre>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b>v<a href=files/swaks-20040404.1>20040404.1</a></b></font></td>
-<td><font size=-1>
-<pre>
+            </code></pre>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="two columns">
+            <b>20040404.1</b>
+        </div>
+        <div class="ten columns">
+            <p>
+                <b>Links:</b>
+                <a href="./files/swaks-20040404.1">script only</a>
+            </p>
+            <p>
+                <b>Changelog:</b>
+            </p>
+            <pre><code>
 * 20040404 added --no-data-fixup option to allow a literal DATA
            value to be passed in
 * 20040404 by default, translate all bare newlines to CRLF.  Fixed
            Debian bug 241368
 * 20040404 updated copyright dates
-</pre>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b>v<a href=files/swaks-20040128.1>20040128.1</a></b></font></td>
-<td><font size=-1>
-<pre>
+            </code></pre>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="two columns">
+            <b>20040128.1</b>
+        </div>
+        <div class="ten columns">
+            <p>
+                <b>Links:</b>
+                <a href="./files/swaks-20040128.1">script only</a>
+            </p>
+            <p>
+                <b>Changelog:</b>
+            </p>
+            <pre><code>
 * 20031226 hostname verification broke FROM and HELO options in -l
            file.  fixed.
 * 20040115 fixed some badly formatted POD
@@ -989,13 +1145,23 @@ Notable Bugs Fixed
            (everything before rcpt) and server is otherwise specified,
            don't require a to address. (sugg. ametzler)
 * 20040128 reworked a split to quell a perl -w gripe
-</pre>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b>v<a href=files/swaks-20031218.0>20031218.0</a></b></font></td>
-<td><font size=-1>
-<pre>
+            </code></pre>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="two columns">
+            <b>20031218.0</b>
+        </div>
+        <div class="ten columns">
+            <p>
+                <b>Links:</b>
+                <a href="./files/swaks-20031218.0">script only</a>
+            </p>
+            <p>
+                <b>Changelog:</b>
+            </p>
+            <pre><code>
 * 20031212 added --tls-on-connect option to support smtps (suggested
            by Benjamin Ritcey &lt;exim#ritcey.com&gt;)
 * 20031212 -tlsc implementation uncovered deficiencies in error
@@ -1009,13 +1175,23 @@ Notable Bugs Fixed
 * 20031218 reworked local hostname determination.  hostname() almost
            never fails but gethostbyname can, use first results if
            second call fails.
-</pre>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b>v<a href=files/swaks-20031211.2>20031211.2</a></b></font></td>
-<td><font size=-1>
-<pre>
+            </code></pre>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="two columns">
+            <b>20031211.2</b>
+        </div>
+        <div class="ten columns">
+            <p>
+                <b>Links:</b>
+                <a href="./files/swaks-20031211.2">script only</a>
+            </p>
+            <p>
+                <b>Changelog:</b>
+            </p>
+            <pre><code>
 * 20031211 the subscripting in the date routine was incorrect, failed
            to compile on older perls
 * 20031211 removed -U and -F options from the perldoc call for --help.
@@ -1024,13 +1200,23 @@ Notable Bugs Fixed
            that case and printed a more informative message
 * 20031211 duh.  if --help run as root, just change to uid 1 before
            running perldoc.  no fuss no muss
-</pre>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b>v<a href=files/swaks-20031210.0>20031210.0</a></b></font></td>
-<td><font size=-1>
-<pre>
+            </code></pre>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="two columns">
+            <b>20031210.0</b>
+        </div>
+        <div class="ten columns">
+            <p>
+                <b>Links:</b>
+                <a href="./files/swaks-20031210.0">script only</a>
+            </p>
+            <p>
+                <b>Changelog:</b>
+            </p>
+            <pre><code>
 * 20031201 changed name from vmail to swaks (SWiss Army Knife Smtp)
 * 20031201 changed copyright/license to GPL
 * 20031207 changed %D body token to be compliant for an RFC Date: header
@@ -1045,13 +1231,23 @@ Notable Bugs Fixed
            makes much more sense in a timeout situation
 * 20031210 implemented automatic routing of RFC821 decimal domain
            literals (user@#16909060).
-</pre>
-</td></tr>
-<tr><td align=center colspan=2><hr width=25%></td></tr>
-<tr>
-<td valign=top><font size=-1><b>v<a href=files/vmail.20031111.0>20031111.0</a></b></font></td>
-<td><font size=-1>
-<pre>
+            </code></pre>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="two columns">
+            <b>20031111.0</b>
+        </div>
+        <div class="ten columns">
+            <p>
+                <b>Links:</b>
+                <a href="./files/vmail.20031111.0">script only</a>
+            </p>
+            <p>
+                <b>Changelog:</b>
+            </p>
+            <pre><code>
 * 20011219 initial implementation
 * 20011220 added ability to specify pieces to be prompted for
            interactively. trumps both file and CL args (-i)
@@ -1215,14 +1411,20 @@ Notable Bugs Fixed
            general streamlining
 * 20031108 missed a piece in implementing DIGEST-MD5 (missed checking
            for Authen::DigestMD5)
-</pre>
-</font></td></tr>
-</table>
+            </code></pre>
+        </div>
+    </div>
 
+</div> <!-- end of content container -->
 
-<table cellpadding=3 border=0 width=600>
-<tr><td align=center>
-<font size=-2><a href=/john/>www.jetmore.org/john</a>/<a href=/john/code/>code</a>/<a href=/john/code/swaks/>swaks</a></font>/<font size=+1>versions.html</font>
-</td></tr>
-</table>
-</td></tr></table></body></html>
+<div class="section footer">
+    <div class="container">
+        <div class="row">
+            <hr/>
+            <p><a href="/john/">www.jetmore.org/john</a> / <a href="/john/code/">code</a> / <a href="/john/code/swaks/">swaks</a> / <b>versions</b></p>
+        </div>
+    </div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Based on minimal Skeleton CSS boilerplate: no tables, more white space, larger text, responsive/mobile friendly view. Page max width is now limited to 600px, as the original.