### PR TITLE
add --smtputf8 support

### DIFF
--- a/doc/base.pod
+++ b/doc/base.pod
@@ -439,6 +439,10 @@ If the remote server supports it, attempt SMTP PIPELINING (RFC 2920). (Arg-None)
 
 If the server supports it, attempt Per-Recipient Data Response (PRDR) (L<https://tools.ietf.org/html/draft-hall-prdr-00.txt>).  PRDR is not yet standardized, but MTAs have begun implementing the proposal. (Arg-None)
 
+=item --smtputf8
+
+If the server supports it, attempt SMTPUTF8 (RFC 6531). (Arg-None)
+
 =item --force-getpwuid
 
 Tell Swaks to use the getpwuid method of finding the default sender local-part instead of trying C<$LOGNAME> first. (Arg-None)
@@ -1120,6 +1124,10 @@ error in TLS transaction
 =item Z<>30
 
 PRDR requested/required but not advertised
+
+=item Z<>31
+
+SMTPUTF8 requested/required but not advertised
 
 =item Z<>32
 

--- a/swaks
+++ b/swaks
@@ -301,6 +301,10 @@ sub sendmail {
 		ptrans(12, "Host did not advertise PRDR support");
 		do_smtp_quit(1, 30);
 	}
+	if ($result == 2) {
+		ptrans(12, "Host did not advertise SMTPUTF8 support");
+		do_smtp_quit(1, 31);
+	}
 	do_smtp_drop()     if ($G::drop_after eq 'mail');
 	do_smtp_quit(1, 0) if ($G::quit_after eq 'mail');
 
@@ -925,6 +929,8 @@ sub do_smtp_helo {
 				} elsif ($l =~ /^PIPELINING$/) {
 					$e->{PIPELINING} = 1;
 					$G::pipeline_adv = 1;
+				} elsif ($l =~ /^SMTPUTF8$/) {
+					$e->{SMTPUTF8} = 1;
 				} elsif ($l =~ /^PRDR$/) {
 					$e->{PRDR} = 1;
 				}
@@ -949,6 +955,14 @@ sub do_smtp_mail {
 			return(1); # PRDR was required but was not advertised.  Return error and let caller handle it
 		} else {
 			$m .= " PRDR";
+		}
+	}
+
+	if ($G::smtputf8) {
+		if (!$e->{SMTPUTF8}) {
+			return(2); # SMTPUTF8 was required but was not advertised.  Return error and let caller handle it
+		} else {
+			$m .= " SMTPUTF8";
 		}
 	}
 
@@ -1981,6 +1995,10 @@ sub get_option_struct {
 		{ opts    => ['prdr'],                                             suffix => '',
 		  cfgs    => OP_ARG_NONE,
 		  okey    => 'prdr',                                               type   => 'scalar', },
+		# attempt SMTPUTF8
+		{ opts    => ['smtputf8'],                                         suffix => '',
+		  cfgs    => OP_ARG_NONE,
+		  okey    => 'smtputf8',                                           type   => 'scalar', },
 		# use getpwuid building -f
 		{ opts    => ['force-getpwuid'],                                   suffix => '',
 		  cfgs    => OP_ARG_NONE,
@@ -2691,6 +2709,7 @@ sub process_args {
 	$G::protect_prompt     = get_arg('protect_prompt', $o);
 	$G::pipeline           = get_arg('pipeline', $o);
 	$G::prdr               = get_arg('prdr', $o);
+	$G::smtputf8           = get_arg('smtputf8', $o);
 	$G::silent             = get_arg('silent', $o) || 0;
 
 	if (defined(my $dump_args = get_arg('dump_args', $o))) {
@@ -3619,6 +3638,7 @@ sub get_running_state {
 			"  timeout         = $G::link{timeout}",
 			'  pipeline        = ' . ($G::pipeline    ? 'TRUE' : 'FALSE'),
 			'  prdr            = ' . ($G::prdr        ? 'TRUE' : 'FALSE'),
+			'  smtputf8        = ' . ($G::smtputf8    ? 'TRUE' : 'FALSE'),
 		]);
 	}
 


### PR DESCRIPTION
Hi John,

this is just adding support for the SMTPUTF8 parameter in the MAIL command, closely following the change in 9ce718120f105dc56a4766ee4d001ffc9e5f8277 for --prdr support.

Cheers
Wolfgang