### PR TITLE
add Dockerfile for Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.9.6
+LABEL maintainer="Bryan CS <@iambryancs>"
+
+RUN apk add --update perl curl perl-net-ssleay
+
+RUN curl -O https://jetmore.org/john/code/swaks/files/swaks-20201014.0/swaks
+
+RUN chmod +x ./swaks
+
+ENTRYPOINT ["./swaks"]
+
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-FROM alpine:3.9.6
+FROM alpine:3.23
+
+LABEL maintainer="John Jetmore <@jetmore>"
 LABEL maintainer="Bryan CS <@iambryancs>"
+
+ENV RELEASE=20240103.0
 
 RUN apk add --update perl curl perl-net-ssleay
 
-RUN curl -O https://jetmore.org/john/code/swaks/files/swaks-20201014.0/swaks
+RUN curl -O https://www.jetmore.org/john/code/swaks/files/swaks-${RELEASE}/swaks
 
 RUN chmod +x ./swaks
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,25 @@ See the [installation page][installation_page] for details on installing in mult
 
 There is also a [versions page][versions_page] which lists every released version of Swaks, complete with changelogs and download links.
 
+## Docker
+
+Usage:
+```
+docker run --rm -ti bryancs/swaks [OPTIONS]
+```
+
+Example:
+```
+# test
+docker run --rm -ti bryancs/swaks \
+  -f foo@bar.com \
+  -t foo@baz.com \
+  -s localhost
+
+# help
+docker run --rm bryancs/swaks --help
+```
+
 ## Documentation
 
 The reference documentation from the latest release, which includes quick-start examples, is available as [plain text][plain_doc] and [rendered][rendered_doc].  The documentation from each release is available from the [versions page][versions_page].  There is also an [Occasionally Asked Questions][oaq] document.


### PR DESCRIPTION
Hi John, this PR adds support for Docker. Very useful in my case where I do tests on dev k8s cluster.
Also useful on any system with Docker that don't want to deal with installing CPAN/Perl and other extensions like Net-SSLeay.

Usage:
```
docker run --rm -ti jetmore/swaks [OPTIONS]
```

Example:
```
# test
docker run --rm -ti jetmore/swaks \
  -f foo@bar.com \
  -t foo@baz.com \
  -s localhost

# help
docker run --rm jetmore/swaks --help
```
