### PR TITLE
Switch modules from INET6 to IP

### DIFF
--- a/swaks
+++ b/swaks
@@ -12,6 +12,7 @@
 use strict;
 use Pod::Usage;
 use File::Spec::Functions qw(splitdir);
+use IO::Socket::IP;
 
 binmode(STDOUT);
 binmode(STDERR);
@@ -116,34 +117,19 @@ sub open_link {
 		push(@extra_options, "LocalAddr", $G::link{lint})  if ($G::link{lint});
 		push(@extra_options, "LocalPort", $G::link{lport}) if ($G::link{lport});
 
-		# INET6 also supports v4, so use it for everything if it's available.  That
-		# allows the module to handle A vs AAAA records on domain lookups where the
-		# user hasn't set a specific ip version to be used.  If INET6 isn't available
-		# and it's a domain that only has AAAA records, INET will just handle it like
-		# a bogus record and we just won't be able to connect
-		if (avail("ipv6")) {
-			if ($G::link{force_ipv6}) {
-				push(@extra_options, "Domain", Socket::AF_INET6() );
-			} elsif ($G::link{force_ipv4}) {
-				push(@extra_options, "Domain", Socket::AF_INET() );
-			}
-
-			$G::link{sock} = IO::Socket::INET6->new(
-				PeerAddr  => $G::link{server},
-				PeerPort  => $G::link{port},
-				Proto     => 'tcp',
-				Timeout   => $G::link{timeout},
-				@extra_options
-			);
-		} else {
-			$G::link{sock} = IO::Socket::INET->new(
-				PeerAddr  => $G::link{server},
-				PeerPort  => $G::link{port},
-				Proto     => 'tcp',
-				Timeout   => $G::link{timeout},
-				@extra_options
-			);
+		if ($G::link{force_ipv6}) {
+			push(@extra_options, "Family", Socket::AF_INET6() );
+			push(@extra_options, 'V6Only', 1);
+		} elsif ($G::link{force_ipv4}) {
+			push(@extra_options, "Family", Socket::AF_INET() );
 		}
+		$G::link{sock} = IO::Socket::IP->new(
+			PeerAddr  => $G::link{server},
+			PeerPort  => $G::link{port},
+			Proto     => 'tcp',
+			Timeout   => $G::link{timeout},
+			@extra_options
+		);
 
 		if ($@) {
 			ptrans(12, "Error connecting" . ($G::link{lint} ? " $G::link{lint}" : '') .
@@ -1743,20 +1729,20 @@ sub time_to_seconds {
 sub load_dependencies {
 	%G::dependencies = (
 		auth            => { name => "Basic AUTH",               opt => ['MIME::Base64'],
-		                                                         req => []                    },
-		auth_cram_md5   => { name => "AUTH CRAM-MD5",            req => ['Digest::MD5']       },
-		auth_cram_sha1  => { name => "AUTH CRAM-SHA1",           req => ['Digest::SHA']       },
-		auth_ntlm       => { name => "AUTH NTLM",                req => ['Authen::NTLM']      },
-		auth_digest_md5 => { name => "AUTH DIGEST-MD5",          req => ['Authen::SASL']      },
-		dns             => { name => "MX Routing",               req => ['Net::DNS']          },
-		netrc           => { name => 'Netrc Credentials',        req => ['Net::Netrc']        },
-		tls             => { name => "TLS",                      req => ['Net::SSLeay']       },
-		pipe            => { name => "Pipe Transport",           req => ['IPC::Open2']        },
-		socket          => { name => "Socket Transport",         req => ['IO::Socket']        },
-		ipv6            => { name => "IPv6",                     req => ['IO::Socket::INET6'] },
-		date_manip      => { name => "Date Manipulation",        req => ['POSIX']             },
-		hostname        => { name => "Local Hostname Detection", req => ['Sys::Hostname']     },
-		hires_timing    => { name => "High Resolution Timing",   req => ['Time::HiRes']       },
+		                                                         req => []                 },
+		auth_cram_md5   => { name => "AUTH CRAM-MD5",            req => ['Digest::MD5']    },
+		auth_cram_sha1  => { name => "AUTH CRAM-SHA1",           req => ['Digest::SHA']    },
+		auth_ntlm       => { name => "AUTH NTLM",                req => ['Authen::NTLM']   },
+		auth_digest_md5 => { name => "AUTH DIGEST-MD5",          req => ['Authen::SASL']   },
+		dns             => { name => "MX Routing",               req => ['Net::DNS']       },
+		netrc           => { name => 'Netrc Credentials',        req => ['Net::Netrc']     },
+		tls             => { name => "TLS",                      req => ['Net::SSLeay']    },
+		pipe            => { name => "Pipe Transport",           req => ['IPC::Open2']     },
+		socket          => { name => "Socket Transport",         req => ['IO::Socket']     },
+		ip              => { name => "IPv4/6",                   req => ['IO::Socket::IP'] },
+		date_manip      => { name => "Date Manipulation",        req => ['POSIX']          },
+		hostname        => { name => "Local Hostname Detection", req => ['Sys::Hostname']  },
+		hires_timing    => { name => "High Resolution Timing",   req => ['Time::HiRes']    },
 	);
 }
 
@@ -3081,8 +3067,8 @@ sub process_args {
 		if (!avail("socket")) {
 			ptrans(12, avail_str("socket").".  Exiting");
 			exit(10);
-		} elsif (($G::link{force_ipv6} || $G::link{server} =~ m|:| ||  $G::link{lint} =~ m|:|) && !avail("ipv6")) {
-			ptrans(12, avail_str("ipv6").".  Exiting");
+		} elsif (($G::link{force_ipv6} || $G::link{server} =~ m|:| ||  $G::link{lint} =~ m|:|) && !avail("ip")) {
+			ptrans(12, avail_str("ip").".  Exiting");
 			exit(10);
 		}
 	}

--- a/swaks
+++ b/swaks
@@ -12,7 +12,6 @@
 use strict;
 use Pod::Usage;
 use File::Spec::Functions qw(splitdir);
-use IO::Socket::IP;
 
 binmode(STDOUT);
 binmode(STDERR);
@@ -110,6 +109,10 @@ sub teardown_link {
 
 sub open_link {
 	if ($G::link{type} eq 'socket-inet') {
+		if (!avail("ip")) {
+			ptrans(12, avail_str("ip").".  Exiting");
+			exit(10);
+		}
 		ptrans(11, 'Trying ' . $G::link{server} . ':' . $G::link{port} . '...');
 		$@ = "";
 

--- a/testing/server/smtp-server.pl
+++ b/testing/server/smtp-server.pl
@@ -2,9 +2,15 @@
 
 # add tls support for all domains
 
-# ./smtp-server.pl -p 8026 scripts/basic-successful-email.txt
+
+# ./smtp-server.pl -p 8026 scripts/script-basic-success.txt
 # ./swaks -s 127.0.0.1 -p 8026 -t foo@example.com
 
+# ./smtp-server.pl -p 8026 scripts/script-tls-success.txt
+# ./swaks -s 127.0.0.1 -p 8026 -t foo@example.com -tls
+
+# ./smtp-server.pl -p 8026 -i ::1 -d inet scripts/script-basic-success.txt
+# ./swaks -s ::1 -p 8026 -t foo@example.com -6
 
 
 # ./smtp-server -p 8026 -i 127.0.0.1 -d inet
@@ -20,7 +26,7 @@ use strict;
 no strict "subs";
 use Socket;
 use IO::Socket;
-use IO::Socket::INET6;
+use IO::Socket::IP;
 use Getopt::Long;
 use Net::SSLeay qw(die_now die_if_ssl_error);
 use FindBin qw($Bin);
@@ -172,7 +178,7 @@ sub set_up_cxn {
     }
     print L "listening on $lint pid $$\n" if (!$opt{silent});
   } else {
-    if (!($server = IO::Socket::INET6->new(Proto => 'tcp', Listen => SOMAXCONN, ReuseAddr => 1, LocalAddr => $lint, LocalPort => $port))) {
+    if (!($server = IO::Socket::IP->new(Proto => 'tcp', Listen => SOMAXCONN, ReuseAddr => 1, LocalAddr => $lint, LocalPort => $port))) {
       mexit(2, "Couldn't be an inet domain server on $lint($port): $@");
     }
     print L "listening on $lint($port) pid $$\n" if (!$opt{silent});


### PR DESCRIPTION
Since Perl 5.14, [IO::Socket::IP](https://metacpan.org/pod/IO::Socket::IP) supports both IPv4 and IPv6, and [IO::Socket::INET6](https://metacpan.org/pod/IO::Socket::INET6) is deprecated.
This pull request removes IO::Socket::INET6 from its dependencies and replaces it with IO::Socket::IP

Closes #43