### PR TITLE
TLS improvements

### DIFF
--- a/Changes
+++ b/Changes
@@ -1036,3 +1036,5 @@
 * 20231203 Clean up the output when we print local and peer cert info, make it
            more compact and uniform
 * 20240102 Update copyright year to 2024
+* 20240102 Print all available certificate information even if TLS was not
+           successfully negotiated

--- a/Changes
+++ b/Changes
@@ -1038,3 +1038,7 @@
 * 20240102 Update copyright year to 2024
 * 20240102 Print all available certificate information even if TLS was not
            successfully negotiated
+* 20240102 Rework tls verification. On cert verification failure, print
+           openssl's error message.  Get rid of verify callback.
+* 20240102 Clarify --tls-verify-ca docs, this verifies both signing and
+           date expiration (notBefore/notAfter)

--- a/doc/base.pod
+++ b/doc/base.pod
@@ -521,13 +521,13 @@ By default, TLS verification is not required.  If TLS verification is required b
 
 =item --tls-verify-ca
 
-Require that the server's certificate be signed by a known certificate authority.  By default the list of known CAs will be whatever is available via the client Swaks is running on.  To provide a custom CA, see C<--tls-ca-path>. (Arg-None)
+Require that the server's certificate be signed by a known certificate authority and not be expired.  By default the list of known CAs will be whatever is available via the client Swaks is running on.  To provide a custom CA, see C<--tls-ca-path>. (Arg-None)
 
 =item --tls-verify-host
 
 Require that the target of the current connection be listed in the server certificate's Subject Alternative Name (SAN) or Subject CommonName (CN).
 
-The target that Swaks uses for verification will vary.  It can be a hostname, either provided directly via the C<--server> option or looked up via MX records.  In this case, verification performs as expected.  If the target is an IP, the IP will be looked up in the certificate, which is possible but usual.  If the transport is C<--pipe> or C<--socket>, there will not be a meaningful target to verify in the certificate and verification will fail.  In this situation it's better to use only C<--tls-verify-ca> or to override the target used for verification with the C<--tls-verify-target> option. (Arg-None)
+The target that Swaks uses for verification will vary.  It can be a hostname, either provided directly via the C<--server> option or looked up via MX records.  In this case, verification performs as expected.  If the target is an IP, the IP will be looked up in the certificate, which is possible but unusual.  If the transport is C<--pipe> or C<--socket>, there will not be a meaningful target to verify in the certificate and verification will fail.  In this situation it's better to use only C<--tls-verify-ca> or to override the target used for verification with the C<--tls-verify-target> option. (Arg-None)
 
 =item --tls-verify-target <verification-string>
 

--- a/swaks
+++ b/swaks
@@ -213,7 +213,6 @@ sub sendmail {
 	# start up tls if -tlsc specified
 	if ($G::tls_on_connect) {
 		if (start_tls()) {
-			tls_post_start();
 			do_smtp_drop()     if ($G::drop_after eq 'tls' || $G::drop_after_send eq 'tls');
 			do_smtp_quit(1, 0) if ($G::quit_after eq 'tls');
 		} else {
@@ -387,44 +386,6 @@ sub xclient_try {
 	}
 	do_smtp_drop()     if ($G::drop_after =~ /xclient(?:-helo)?/ || $G::drop_after_send =~ /xclient(?:-helo)?/);
 	do_smtp_quit(1, 0) if ($G::quit_after =~ /xclient(?:-helo)?/);
-}
-
-sub tls_post_start {
-	ptrans(11, "TLS started with cipher $G::link{tls}{cipher_string}");
-	ptrans(11, "TLS client certificate " . ($G::link{tls}{server_requested_cert} ? '' : 'not ') . "requested and " . ($G::link{tls}{client_sent_cert} ? '' : 'not ') . "sent");
-	if (!exists($G::link{tls}{local_certs}) || !ref($G::link{tls}{local_certs}) eq 'ARRAY' || !scalar(@{$G::link{tls}{local_certs}})) {
-		ptrans(11, "TLS no client certificate set");
-	} else {
-		for (my $i = 0; $i < scalar(@{$G::link{tls}{local_certs}}); $i++) {
-			print_cert_info($G::link{tls}{local_certs}, $i, "client");
-		}
-	}
-	for (my $i = 0; $i < scalar(@{$G::link{tls}{cert_chain}}); $i++) {
-		print_cert_info($G::link{tls}{cert_chain}, $i, "peer");
-	}
-	ptrans(11, sprintf("TLS peer certificate %s CA verification, %s host verification (%s)",
-		$G::link{tls}{server_cert_verified_ca}   ? 'passed' : 'failed',
-		$G::link{tls}{server_cert_verified_host} ? 'passed' : 'failed',
-		$G::link{tls}{server_cert_host_target} ? "using host $G::link{tls}{server_cert_host_target} to verify" : "no host string available to verify"
-	));
-
-	if ($G::tls_get_peer_cert eq 'STDOUT') {
-		ptrans(11, $G::link{tls}{cert_x509});
-	} elsif ($G::tls_get_peer_cert) {
-		open(CERT, ">$G::tls_get_peer_cert") ||
-			ptrans(12, "Couldn't open $G::tls_get_peer_cert for writing: $!");
-		print CERT $G::link{tls}{cert_x509}, "\n";
-		close(CERT);
-	}
-
-	if ($G::tls_get_peer_chain eq 'STDOUT') {
-		ptrans(11, join("\n", @{$G::link{tls}{chain_x509}}));
-	} elsif ($G::tls_get_peer_chain) {
-		open(CERT, ">$G::tls_get_peer_chain") ||
-			ptrans(12, "Couldn't open $G::tls_get_peer_chain for writing: $!");
-		print CERT join("\n", @{$G::link{tls}{chain_x509}}), "\n";
-		close(CERT);
-	}
 }
 
 sub print_cert_info {
@@ -732,6 +693,7 @@ sub start_tls_post_connect {
 		$t->{verify_failure_message} = join(', ', map { $t->{server_cert_error_components}{$_} } sort(keys(%{$t->{server_cert_error_components}})));
 	}
 
+	# this is a real negotiate failure, not a verification failure
 	if (!$t->{active}) {
 		$t->{res} = "connect(): " . Net::SSLeay::ERR_error_string(Net::SSLeay::ERR_get_error());
 		if ($t->{verify_failure_message}) {
@@ -739,11 +701,8 @@ sub start_tls_post_connect {
 		}
 		return(0);
 	}
-	elsif (!$t->{server_cert_verification_status}) {
-		$t->{res} = "connect(): " . $t->{verify_failure_message};
-		return(0);
-	}
 
+	# STORE connection information
 	# egrep 'define.*VERSION\b' *.h
 	# when adding new types here, see also the code that pushes supported values onto tls_supported_protocols
 	$t->{version} = Net::SSLeay::version($t->{ssl});
@@ -794,6 +753,49 @@ sub start_tls_post_connect {
 		$t->{local_cert}            = Net::SSLeay::get_certificate($t->{ssl});
 		chomp($t->{local_cert_x509} = Net::SSLeay::PEM_get_string_X509($t->{local_cert}));
 		$t->{local_cert_subject}    = Net::SSLeay::X509_NAME_oneline(Net::SSLeay::X509_get_subject_name($t->{local_cert}));
+	}
+
+	# DISPLAY connection information.  Could probably be combined with saving, they were two different steps in the past
+	ptrans(11, "TLS started with cipher $G::link{tls}{cipher_string}");
+	ptrans(11, "TLS client certificate " . ($G::link{tls}{server_requested_cert} ? '' : 'not ') . "requested and " . ($G::link{tls}{client_sent_cert} ? '' : 'not ') . "sent");
+	if (!exists($G::link{tls}{local_certs}) || !ref($G::link{tls}{local_certs}) eq 'ARRAY' || !scalar(@{$G::link{tls}{local_certs}})) {
+		ptrans(11, "TLS no client certificate set");
+	} else {
+		for (my $i = 0; $i < scalar(@{$G::link{tls}{local_certs}}); $i++) {
+			print_cert_info($G::link{tls}{local_certs}, $i, "client");
+		}
+	}
+	for (my $i = 0; $i < scalar(@{$G::link{tls}{cert_chain}}); $i++) {
+		print_cert_info($G::link{tls}{cert_chain}, $i, "peer");
+	}
+	ptrans(11, sprintf("TLS peer certificate %s CA verification, %s host verification (%s)",
+		$G::link{tls}{server_cert_verified_ca}   ? 'passed' : 'failed',
+		$G::link{tls}{server_cert_verified_host} ? 'passed' : 'failed',
+		$G::link{tls}{server_cert_host_target} ? "using host $G::link{tls}{server_cert_host_target} to verify" : "no host string available to verify"
+	));
+
+	if ($G::tls_get_peer_cert eq 'STDOUT') {
+		ptrans(11, $G::link{tls}{cert_x509});
+	} elsif ($G::tls_get_peer_cert) {
+		open(CERT, ">$G::tls_get_peer_cert") ||
+			ptrans(12, "Couldn't open $G::tls_get_peer_cert for writing: $!");
+		print CERT $G::link{tls}{cert_x509}, "\n";
+		close(CERT);
+	}
+
+	if ($G::tls_get_peer_chain eq 'STDOUT') {
+		ptrans(11, join("\n", @{$G::link{tls}{chain_x509}}));
+	} elsif ($G::tls_get_peer_chain) {
+		open(CERT, ">$G::tls_get_peer_chain") ||
+			ptrans(12, "Couldn't open $G::tls_get_peer_chain for writing: $!");
+		print CERT join("\n", @{$G::link{tls}{chain_x509}}), "\n";
+		close(CERT);
+	}
+
+	# if we got to here we negotiated TLS successfully but there was a verification issue
+	if (!$t->{server_cert_verification_status}) {
+		$t->{res} = "connect(): " . $t->{verify_failure_message};
+		return(0);
 	}
 
 	return(1);
@@ -941,7 +943,6 @@ sub do_smtp_tls {
 		ptrans(12, "TLS startup failed ($G::link{tls}{res})");
 		return(2);
 	}
-	tls_post_start();
 
 	return(0);
 }

--- a/swaks
+++ b/swaks
@@ -509,50 +509,9 @@ sub start_tls_build_ctx {
 	}
 	Net::SSLeay::CTX_set_options($t->{con}, $ctx_options);
 
-	# This callback can get called multiple times, once per cert in the chain.  Because of that we have to be careful in how
-	# we design it - CA verification is sticky on failure (any cert failure means the whole thing is a failure) and loose
-	# on hostname verification (any hostname success is a success).  Also, we might generate the same error multiple times,
-	# so we need to figure out how to remove duplicates
-	Net::SSLeay::CTX_set_verify($t->{con}, &Net::SSLeay::VERIFY_PEER, sub {
-		my $preverify_ok = shift;
-		my $x509_ctx     = shift;
-
-		#my $x509 = Net::SSLeay::X509_STORE_CTX_get_current_cert($x509_ctx);
-		# print STDERR "CALLING CTX_set_verify($preverify_ok): " . Net::SSLeay::X509_NAME_oneline(Net::SSLeay::X509_get_subject_name($x509)) . "\n";
-
-		# we don't have to do the ca verification, that's handled before we get here
-		# we shape it like this because any cert failure fails the whole chain for cert verification
-		if (!$preverify_ok) {
-			$t->{server_cert_verified_ca} = 0;
-			$t->{server_cert_error_components}{A_sign} = 'server certificate not signed by known CA';
-		}
-
-		if (!$t->{server_cert_host_target}) {
-			$t->{server_cert_error_components}{B_host} = "no host available for host verification";
-		}
-		else {
-			my $x509 = Net::SSLeay::X509_STORE_CTX_get_current_cert($x509_ctx);
-			if ($t->{server_cert_host_target} =~ /(:|^\d+\.\d+\.\d+\.\d+$)/) {
-				# verify as an IP
-				if (Net::SSLeay::X509_check_ip_asc($x509, $t->{server_cert_host_target}, 0) == 1) {
-					$t->{server_cert_verified_host} = 1;
-				}
-			}
-			else {
-				# verify as a hostname
-				if (Net::SSLeay::X509_check_host($x509, $t->{server_cert_host_target}, 0) == 1) {
-					$t->{server_cert_verified_host} = 1;
-				}
-			}
-
-			if (!$t->{server_cert_verified_host}) {
-				$t->{server_cert_error_components}{B_host} = 'server certificate did not match target host ' . $t->{server_cert_host_target};
-			}
-		}
-
-		# we return success unconditionally and then handle anything we don't like after the connection
-		return 1;
-	});
+	# Set our verification to VERIFY_NONE.  This means openssl won't fail, but we will still get a report if it doesn't verify.
+	# If that happens, we will report it in our own way instead of just killing the transaction.
+	Net::SSLeay::CTX_set_verify($t->{con}, &Net::SSLeay::VERIFY_NONE);
 
 	# This callback is called at various stages of the TLS negotiation.  Currently used to determine whether the server requested
 	# a certificate. CTX_set_client_cert_cb (cf https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_client_cert_cb.html)
@@ -681,24 +640,9 @@ sub start_tls_connect {
 sub start_tls_post_connect {
 	my $t = shift;
 
-	# Our verification callback always succeeds, so we need to actually evaluate whether we should consider the connection successful here
-	$t->{server_cert_verification_status} = 1;
-	if ($G::tls_verify_ca && !$t->{server_cert_verified_ca}) {
-		$t->{server_cert_verification_status} = 0;
-	}
-	if ($G::tls_verify_host && !$t->{server_cert_verified_host}) {
-		$t->{server_cert_verification_status} = 0;
-	}
-	if (scalar(keys(%{$t->{server_cert_error_components}}))) {
-		$t->{verify_failure_message} = join(', ', map { $t->{server_cert_error_components}{$_} } sort(keys(%{$t->{server_cert_error_components}})));
-	}
-
 	# this is a real negotiate failure, not a verification failure
 	if (!$t->{active}) {
 		$t->{res} = "connect(): " . Net::SSLeay::ERR_error_string(Net::SSLeay::ERR_get_error());
-		if ($t->{verify_failure_message}) {
-			$t->{res} .= ' (' . $t->{verify_failure_message} . ')';
-		}
 		return(0);
 	}
 
@@ -755,6 +699,52 @@ sub start_tls_post_connect {
 		$t->{local_cert_subject}    = Net::SSLeay::X509_NAME_oneline(Net::SSLeay::X509_get_subject_name($t->{local_cert}));
 	}
 
+	# do hostname verification.  This is only done on the peer cert (not the chain)
+	if (!$t->{server_cert_host_target}) {
+		$t->{server_cert_error_components}{B_host} = "no host available for host verification";
+	}
+	else {
+		# my $x509 = Net::SSLeay::X509_STORE_CTX_get_current_cert($x509_ctx);
+		my $x509 = $t->{cert};
+		if ($t->{server_cert_host_target} =~ /(:|^\d+\.\d+\.\d+\.\d+$)/) {
+			# verify as an IP
+			if (Net::SSLeay::X509_check_ip_asc($x509, $t->{server_cert_host_target}, 0) == 1) {
+				$t->{server_cert_verified_host} = 1;
+			}
+		}
+		else {
+			# verify as a hostname
+			# print STDERR "XXXXX ", Net::SSLeay::X509_check_host($x509, $t->{server_cert_host_target}, 0), "\n";;
+			if (Net::SSLeay::X509_check_host($x509, $t->{server_cert_host_target}, 0) == 1) {
+				$t->{server_cert_verified_host} = 1;
+			}
+		}
+
+		if (!$t->{server_cert_verified_host}) {
+			$t->{server_cert_error_components}{B_host} = 'server certificate did not match target host ' . $t->{server_cert_host_target};
+		}
+	}
+
+	# certificate verification
+	my $verifyResult = Net::SSLeay::get_verify_result($t->{ssl});
+	my $verifyResultString = '';
+	$t->{server_cert_verified_ca} = $verifyResult == 0;
+	if (!$t->{server_cert_verified_ca}) {
+		$verifyResultString = Net::SSLeay::X509_verify_cert_error_string($verifyResult);
+		$t->{server_cert_error_components}{A_sign} = 'certificate verification failed (' . $verifyResultString . ')';
+	}
+
+	$t->{server_cert_verification_status} = 1;
+	if ($G::tls_verify_ca && !$t->{server_cert_verified_ca}) {
+		$t->{server_cert_verification_status} = 0;
+	}
+	if ($G::tls_verify_host && !$t->{server_cert_verified_host}) {
+		$t->{server_cert_verification_status} = 0;
+	}
+	if (scalar(keys(%{$t->{server_cert_error_components}}))) {
+		$t->{verify_failure_message} = join(', ', map { $t->{server_cert_error_components}{$_} } sort(keys(%{$t->{server_cert_error_components}})));
+	}
+
 	# DISPLAY connection information.  Could probably be combined with saving, they were two different steps in the past
 	ptrans(11, "TLS started with cipher $G::link{tls}{cipher_string}");
 	ptrans(11, "TLS client certificate " . ($G::link{tls}{server_requested_cert} ? '' : 'not ') . "requested and " . ($G::link{tls}{client_sent_cert} ? '' : 'not ') . "sent");
@@ -768,8 +758,9 @@ sub start_tls_post_connect {
 	for (my $i = 0; $i < scalar(@{$G::link{tls}{cert_chain}}); $i++) {
 		print_cert_info($G::link{tls}{cert_chain}, $i, "peer");
 	}
-	ptrans(11, sprintf("TLS peer certificate %s CA verification, %s host verification (%s)",
+	ptrans(11, sprintf("TLS peer certificate %s CA verification%s, %s host verification (%s)",
 		$G::link{tls}{server_cert_verified_ca}   ? 'passed' : 'failed',
+		$G::link{tls}{server_cert_verified_ca}   ? '' : ' (' . $verifyResultString . ')',
 		$G::link{tls}{server_cert_verified_host} ? 'passed' : 'failed',
 		$G::link{tls}{server_cert_host_target} ? "using host $G::link{tls}{server_cert_host_target} to verify" : "no host string available to verify"
 	));

--- a/testing/regressions/_exec-transactions/out-ref/00200.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00200.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-STARTTLS

--- a/testing/regressions/_exec-transactions/out-ref/00207.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00207.stdout
@@ -5,7 +5,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
 <~  220 SERVER ESMTP ready
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]

--- a/testing/regressions/_exec-transactions/out-ref/00210.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00210.stdout
@@ -23,7 +23,7 @@
 ===               commonName=[unsigned.example.com], subjectAltName=[DNS:unsigned.example.com] notAfter=[2033-09-11T14:51:48Z]
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-TLS peer 0 DN=/C=US/ST=Indiana/O=Swaks Development (unsigned.example.com, with-SAN)/CN=unsigned.example.com/emailAddress=proj-swaks@jetmore.net

--- a/testing/regressions/_exec-transactions/out-ref/00213.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00213.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
 === -----BEGIN CERTIFICATE-----
 === MIIEGjCCAwKgAwIBAgIUFQU5NT2EO9gtC5YP96Fa9d8vFVkwDQYJKoZIhvcNAQEL
 === BQAwejELMAkGA1UEBhMCVVMxEDAOBgNVBAgMB0luZGlhbmExGjAYBgNVBAoMEVN3

--- a/testing/regressions/_exec-transactions/out-ref/00214.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00214.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-STARTTLS

--- a/testing/regressions/_exec-transactions/out-ref/00215.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00215.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-STARTTLS

--- a/testing/regressions/_exec-transactions/out-ref/00216.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00216.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-STARTTLS

--- a/testing/regressions/_exec-transactions/out-ref/00220.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00220.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-STARTTLS

--- a/testing/regressions/_exec-transactions/out-ref/00221.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00221.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-STARTTLS

--- a/testing/regressions/_exec-transactions/out-ref/00222.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00222.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-STARTTLS

--- a/testing/regressions/_exec-transactions/out-ref/00223.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00223.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-STARTTLS

--- a/testing/regressions/_exec-transactions/out-ref/00224.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00224.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-STARTTLS

--- a/testing/regressions/_exec-transactions/out-ref/00225.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00225.stdout
@@ -23,7 +23,7 @@
 ===               commonName=[unsigned.example.com], subjectAltName=[DNS:unsigned.example.com] notAfter=[2033-09-11T14:51:48Z]
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-STARTTLS

--- a/testing/regressions/_exec-transactions/out-ref/00226.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00226.stdout
@@ -23,7 +23,7 @@
 ===               commonName=[unsigned.example.com], subjectAltName=[DNS:unsigned.example.com] notAfter=[2033-09-11T14:51:48Z]
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-STARTTLS

--- a/testing/regressions/_exec-transactions/out-ref/00227.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00227.stdout
@@ -27,7 +27,7 @@
 ===               commonName=[Swaks Root CA], subjectAltName=[] notAfter=[2030-12-11T15:28:17Z]
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-TLS peer 0 DN=/C=US/ST=Indiana/O=Swaks Development (signed-intermediate.example.com, with-SAN)/CN=signed-intermediate.example.com/emailAddress=proj-swaks@jetmore.net

--- a/testing/regressions/_exec-transactions/out-ref/00228.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00228.stdout
@@ -27,7 +27,7 @@
 ===               commonName=[Swaks Root CA], subjectAltName=[] notAfter=[2030-12-11T15:28:17Z]
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-TLS peer 0 DN=/C=US/ST=Indiana/O=Swaks Development (signed-intermediate.example.com, with-SAN)/CN=signed-intermediate.example.com/emailAddress=proj-swaks@jetmore.net

--- a/testing/regressions/_exec-transactions/out-ref/00229.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00229.stdout
@@ -26,7 +26,7 @@
 ===               commonName=[], subjectAltName=[] notAfter=[2033-09-15T22:49:32Z]
 === TLS peer[2]   subject=[/C=US/ST=Indiana/O=Swaks Development/CN=Swaks Root CA/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[Swaks Root CA], subjectAltName=[] notAfter=[2030-12-11T15:28:17Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (self-signed certificate in certificate chain), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-TLS peer DN=No client certificate present

--- a/testing/regressions/_exec-transactions/out-ref/00230.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00230.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
 === -----BEGIN CERTIFICATE-----
 === MIIEGjCCAwKgAwIBAgIUFQU5NT2EO9gtC5YP96Fa9d8vFVkwDQYJKoZIhvcNAQEL
 === BQAwejELMAkGA1UEBhMCVVMxEDAOBgNVBAgMB0luZGlhbmExGjAYBgNVBAoMEVN3

--- a/testing/regressions/_exec-transactions/out-ref/00231.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00231.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-STARTTLS

--- a/testing/regressions/_exec-transactions/out-ref/00240.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00240.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (unsigned.example.com, with-SAN)/CN=unsigned.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[unsigned.example.com], subjectAltName=[DNS:unsigned.example.com] notAfter=[2033-09-11T14:51:48Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (self-signed certificate), failed host verification (no host string available to verify)
  ~> QUIT
 <~  221 SERVER closing connection
 === Connection closed with child process.

--- a/testing/regressions/_exec-transactions/out-ref/00241.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00241.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (signed.example.com, with-SAN)/CN=signed.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[signed.example.com], subjectAltName=[DNS:signed.example.com] notAfter=[2033-09-11T14:50:47Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> QUIT
 <~  221 SERVER closing connection
 === Connection closed with child process.

--- a/testing/regressions/_exec-transactions/out-ref/00243.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00243.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (unsigned.example.com, with-SAN)/CN=unsigned.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[unsigned.example.com], subjectAltName=[DNS:unsigned.example.com] notAfter=[2033-09-11T14:51:48Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (self-signed certificate), failed host verification (no host string available to verify)
  ~> QUIT
 <~  221 SERVER closing connection
 === Connection closed with remote host.

--- a/testing/regressions/_exec-transactions/out-ref/00244.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00244.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (unsigned.example.com, with-SAN)/CN=unsigned.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[unsigned.example.com], subjectAltName=[DNS:unsigned.example.com] notAfter=[2033-09-11T14:51:48Z]
-=== TLS peer certificate failed CA verification, failed host verification (using host 127.0.0.1 to verify)
+=== TLS peer certificate failed CA verification (self-signed certificate), failed host verification (using host 127.0.0.1 to verify)
  ~> QUIT
 <~  221 SERVER closing connection
 === Connection closed with remote host.

--- a/testing/regressions/_exec-transactions/out-ref/00245.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00245.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (localhost, with-SAN)/CN=localhost/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[localhost], subjectAltName=[DNS:localhost] notAfter=[2033-09-11T14:59:07Z]
-=== TLS peer certificate failed CA verification, passed host verification (using host localhost to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), passed host verification (using host localhost to verify)
  ~> QUIT
 <~  221 SERVER closing connection
 === Connection closed with remote host.

--- a/testing/regressions/_exec-transactions/out-ref/00246.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00246.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (127.0.0.1, with-SAN)/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[], subjectAltName=[IP Address:127.0.0.1] notAfter=[2033-09-11T14:54:07Z]
-=== TLS peer certificate failed CA verification, passed host verification (using host 127.0.0.1 to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), passed host verification (using host 127.0.0.1 to verify)
  ~> QUIT
 <~  221 SERVER closing connection
 === Connection closed with remote host.

--- a/testing/regressions/_exec-transactions/out-ref/00247.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00247.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (unsigned.example.com, with-SAN)/CN=unsigned.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[unsigned.example.com], subjectAltName=[DNS:unsigned.example.com] notAfter=[2033-09-11T14:51:48Z]
-=== TLS peer certificate failed CA verification, failed host verification (using host unknown.example.com to verify)
+=== TLS peer certificate failed CA verification (self-signed certificate), failed host verification (using host unknown.example.com to verify)
  ~> QUIT
 <~  221 SERVER closing connection
 === Connection closed with child process.

--- a/testing/regressions/_exec-transactions/out-ref/00248.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00248.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (unsigned.example.com, with-SAN)/CN=unsigned.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[unsigned.example.com], subjectAltName=[DNS:unsigned.example.com] notAfter=[2033-09-11T14:51:48Z]
-=== TLS peer certificate failed CA verification, passed host verification (using host unsigned.example.com to verify)
+=== TLS peer certificate failed CA verification (self-signed certificate), passed host verification (using host unsigned.example.com to verify)
  ~> QUIT
 <~  221 SERVER closing connection
 === Connection closed with child process.

--- a/testing/regressions/_exec-transactions/out-ref/00249.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00249.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (127.0.0.1, with-SAN)/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[], subjectAltName=[IP Address:127.0.0.1] notAfter=[2033-09-11T14:54:07Z]
-=== TLS peer certificate failed CA verification, failed host verification (using host 127.0.0.2 to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (using host 127.0.0.2 to verify)
  ~> QUIT
 <~  221 SERVER closing connection
 === Connection closed with child process.

--- a/testing/regressions/_exec-transactions/out-ref/00250.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00250.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (127.0.0.1, with-SAN)/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[], subjectAltName=[IP Address:127.0.0.1] notAfter=[2033-09-11T14:54:07Z]
-=== TLS peer certificate failed CA verification, passed host verification (using host 127.0.0.1 to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), passed host verification (using host 127.0.0.1 to verify)
  ~> QUIT
 <~  221 SERVER closing connection
 === Connection closed with child process.

--- a/testing/regressions/_exec-transactions/out-ref/00251.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00251.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (cn-only.example.com, without-SAN)/CN=cn-only.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[cn-only.example.com], subjectAltName=[] notAfter=[2033-09-11T15:03:37Z]
-=== TLS peer certificate failed CA verification, passed host verification (using host cn-only.example.com to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), passed host verification (using host cn-only.example.com to verify)
  ~> QUIT
 <~  221 SERVER closing connection
 === Connection closed with child process.

--- a/testing/regressions/_exec-transactions/out-ref/00252.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00252.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (san-only.example.com, with-SAN)/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[], subjectAltName=[DNS:san-only.example.com] notAfter=[2033-09-11T15:03:56Z]
-=== TLS peer certificate failed CA verification, passed host verification (using host san-only.example.com to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), passed host verification (using host san-only.example.com to verify)
  ~> QUIT
 <~  221 SERVER closing connection
 === Connection closed with child process.

--- a/testing/regressions/_exec-transactions/out-ref/00253.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00253.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (*.example.com, with-SAN)/CN=*.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[*.example.com], subjectAltName=[DNS:*.example.com] notAfter=[2033-09-11T15:02:41Z]
-=== TLS peer certificate failed CA verification, passed host verification (using host anything.example.com to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), passed host verification (using host anything.example.com to verify)
  ~> QUIT
 <~  221 SERVER closing connection
 === Connection closed with child process.

--- a/testing/regressions/_exec-transactions/out-ref/00255.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00255.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (expired-signed.example.com, with-SAN)/CN=expired-signed.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[expired-signed.example.com], subjectAltName=[DNS:expired-signed.example.com] notAfter=[2023-11-02T15:00:55Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (certificate has expired), failed host verification (no host string available to verify)
  ~> QUIT
 <~  221 SERVER closing connection
 === Connection closed with child process.

--- a/testing/regressions/_exec-transactions/out-ref/00256.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00256.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (san-multiple.example.com, with-SAN)/CN=san-multiple.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[san-multiple.example.com], subjectAltName=[DNS:san-multiple.example.com, DNS:san-m1.example.com, DNS:san-m2.example.com] notAfter=[2033-09-11T15:04:20Z]
-=== TLS peer certificate failed CA verification, passed host verification (using host san-m1.example.com to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), passed host verification (using host san-m1.example.com to verify)
  ~> QUIT
 <~  221 SERVER closing connection
 === Connection closed with child process.

--- a/testing/regressions/_exec-transactions/out-ref/00257.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00257.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (localhost, with-SAN)/CN=localhost/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[localhost], subjectAltName=[DNS:localhost] notAfter=[2033-09-11T14:59:07Z]
-=== TLS peer certificate failed CA verification, passed host verification (using host localhost to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), passed host verification (using host localhost to verify)
  ~> QUIT
 <~  221 SERVER closing connection
 === Connection closed with remote host.

--- a/testing/regressions/_exec-transactions/out-ref/00258.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00258.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (::1, with-SAN)/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[], subjectAltName=[IP Address:::1] notAfter=[2033-09-11T14:57:04Z]
-=== TLS peer certificate failed CA verification, passed host verification (using host ::1 to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), passed host verification (using host ::1 to verify)
  ~> QUIT
 <~  221 SERVER closing connection
 === Connection closed with remote host.

--- a/testing/regressions/_exec-transactions/out-ref/00260.stderr
+++ b/testing/regressions/_exec-transactions/out-ref/00260.stderr
@@ -1,2 +1,2 @@
-*** TLS startup failed (connect(): server certificate not signed by known CA, no host available for host verification)
+*** TLS startup failed (connect(): certificate verification failed (unable to get local issuer certificate), no host available for host verification)
 *** STARTTLS attempted but failed

--- a/testing/regressions/_exec-transactions/out-ref/00260.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00260.stdout
@@ -22,4 +22,4 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)

--- a/testing/regressions/_exec-transactions/out-ref/00260.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00260.stdout
@@ -17,3 +17,9 @@
 <-  250 HELP
  -> STARTTLS
 <-  220 TLS go ahead
+=== TLS started with cipher VERSION:CIPHER:BITS
+=== TLS client certificate not requested and not sent
+=== TLS no client certificate set
+=== TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
+===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
+=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)

--- a/testing/regressions/_exec-transactions/out-ref/00261.stderr
+++ b/testing/regressions/_exec-transactions/out-ref/00261.stderr
@@ -1,2 +1,2 @@
-*** TLS startup failed (connect(): server certificate not signed by known CA)
+*** TLS startup failed (connect(): certificate verification failed (unable to get local issuer certificate))
 *** STARTTLS attempted but failed

--- a/testing/regressions/_exec-transactions/out-ref/00261.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00261.stdout
@@ -17,3 +17,9 @@
 <-  250 HELP
  -> STARTTLS
 <-  220 TLS go ahead
+=== TLS started with cipher VERSION:CIPHER:BITS
+=== TLS client certificate not requested and not sent
+=== TLS no client certificate set
+=== TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
+===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
+=== TLS peer certificate failed CA verification, passed host verification (using host node.example.com to verify)

--- a/testing/regressions/_exec-transactions/out-ref/00261.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00261.stdout
@@ -22,4 +22,4 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, passed host verification (using host node.example.com to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), passed host verification (using host node.example.com to verify)

--- a/testing/regressions/_exec-transactions/out-ref/00264.stderr
+++ b/testing/regressions/_exec-transactions/out-ref/00264.stderr
@@ -1,2 +1,2 @@
-*** TLS startup failed (connect(): server certificate not signed by known CA, no host available for host verification)
+*** TLS startup failed (connect(): certificate verification failed (unable to get local issuer certificate), no host available for host verification)
 *** STARTTLS attempted but failed

--- a/testing/regressions/_exec-transactions/out-ref/00264.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00264.stdout
@@ -22,4 +22,4 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)

--- a/testing/regressions/_exec-transactions/out-ref/00264.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00264.stdout
@@ -17,3 +17,9 @@
 <-  250 HELP
  -> STARTTLS
 <-  220 TLS go ahead
+=== TLS started with cipher VERSION:CIPHER:BITS
+=== TLS client certificate not requested and not sent
+=== TLS no client certificate set
+=== TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
+===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
+=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)

--- a/testing/regressions/_exec-transactions/out-ref/00265.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00265.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, passed host verification (using host node.example.com to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), passed host verification (using host node.example.com to verify)
  ~> QUIT
 <~  221 SERVER closing connection
 === Connection closed with child process.

--- a/testing/regressions/_exec-transactions/out-ref/00266.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00266.stdout
@@ -17,3 +17,9 @@
 <-  250 HELP
  -> STARTTLS
 <-  220 TLS go ahead
+=== TLS started with cipher VERSION:CIPHER:BITS
+=== TLS client certificate not requested and not sent
+=== TLS no client certificate set
+=== TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
+===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
+=== TLS peer certificate passed CA verification, failed host verification (using host badhost.example.com to verify)

--- a/testing/regressions/_exec-transactions/out-ref/00268.stderr
+++ b/testing/regressions/_exec-transactions/out-ref/00268.stderr
@@ -1,2 +1,2 @@
-*** TLS startup failed (connect(): server certificate not signed by known CA, no host available for host verification)
+*** TLS startup failed (connect(): certificate verification failed (unable to get local issuer certificate), no host available for host verification)
 *** STARTTLS attempted but failed

--- a/testing/regressions/_exec-transactions/out-ref/00268.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00268.stdout
@@ -22,4 +22,4 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)

--- a/testing/regressions/_exec-transactions/out-ref/00268.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00268.stdout
@@ -17,3 +17,9 @@
 <-  250 HELP
  -> STARTTLS
 <-  220 TLS go ahead
+=== TLS started with cipher VERSION:CIPHER:BITS
+=== TLS client certificate not requested and not sent
+=== TLS no client certificate set
+=== TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
+===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
+=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)

--- a/testing/regressions/_exec-transactions/out-ref/00269.stderr
+++ b/testing/regressions/_exec-transactions/out-ref/00269.stderr
@@ -1,2 +1,2 @@
-*** TLS startup failed (connect(): server certificate not signed by known CA)
+*** TLS startup failed (connect(): certificate verification failed (unable to get local issuer certificate))
 *** STARTTLS attempted but failed

--- a/testing/regressions/_exec-transactions/out-ref/00269.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00269.stdout
@@ -17,3 +17,9 @@
 <-  250 HELP
  -> STARTTLS
 <-  220 TLS go ahead
+=== TLS started with cipher VERSION:CIPHER:BITS
+=== TLS client certificate not requested and not sent
+=== TLS no client certificate set
+=== TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
+===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
+=== TLS peer certificate failed CA verification, passed host verification (using host node.example.com to verify)

--- a/testing/regressions/_exec-transactions/out-ref/00269.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00269.stdout
@@ -22,4 +22,4 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, passed host verification (using host node.example.com to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), passed host verification (using host node.example.com to verify)

--- a/testing/regressions/_exec-transactions/out-ref/00270.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00270.stdout
@@ -17,3 +17,9 @@
 <-  250 HELP
  -> STARTTLS
 <-  220 TLS go ahead
+=== TLS started with cipher VERSION:CIPHER:BITS
+=== TLS client certificate not requested and not sent
+=== TLS no client certificate set
+=== TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
+===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
+=== TLS peer certificate passed CA verification, failed host verification (using host badhost.example.com to verify)

--- a/testing/regressions/_exec-transactions/out-ref/00272.stderr
+++ b/testing/regressions/_exec-transactions/out-ref/00272.stderr
@@ -1,2 +1,2 @@
-*** TLS startup failed (connect(): server certificate not signed by known CA, no host available for host verification)
+*** TLS startup failed (connect(): certificate verification failed (unable to get local issuer certificate), no host available for host verification)
 *** STARTTLS attempted but failed

--- a/testing/regressions/_exec-transactions/out-ref/00272.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00272.stdout
@@ -22,4 +22,4 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)

--- a/testing/regressions/_exec-transactions/out-ref/00272.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00272.stdout
@@ -17,3 +17,9 @@
 <-  250 HELP
  -> STARTTLS
 <-  220 TLS go ahead
+=== TLS started with cipher VERSION:CIPHER:BITS
+=== TLS client certificate not requested and not sent
+=== TLS no client certificate set
+=== TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
+===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
+=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)

--- a/testing/regressions/_exec-transactions/out-ref/00273.stderr
+++ b/testing/regressions/_exec-transactions/out-ref/00273.stderr
@@ -1,2 +1,2 @@
-*** TLS startup failed (connect(): server certificate not signed by known CA, server certificate did not match target host foo.example.com)
+*** TLS startup failed (connect(): certificate verification failed (unable to get local issuer certificate), server certificate did not match target host foo.example.com)
 *** STARTTLS attempted but failed

--- a/testing/regressions/_exec-transactions/out-ref/00273.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00273.stdout
@@ -17,3 +17,9 @@
 <-  250 HELP
  -> STARTTLS
 <-  220 TLS go ahead
+=== TLS started with cipher VERSION:CIPHER:BITS
+=== TLS client certificate not requested and not sent
+=== TLS no client certificate set
+=== TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
+===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
+=== TLS peer certificate failed CA verification, failed host verification (using host foo.example.com to verify)

--- a/testing/regressions/_exec-transactions/out-ref/00273.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00273.stdout
@@ -22,4 +22,4 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (using host foo.example.com to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (using host foo.example.com to verify)

--- a/testing/regressions/_exec-transactions/out-ref/00310.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00310.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-STARTTLS

--- a/testing/regressions/_exec-transactions/out-ref/00311.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00311.stdout
@@ -38,7 +38,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-STARTTLS

--- a/testing/regressions/_exec-transactions/out-ref/00626.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00626.stdout
@@ -12,7 +12,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-STARTTLS

--- a/testing/regressions/_exec-transactions/out-ref/00804.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/00804.stdout
@@ -6,7 +6,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (using host 127.0.0.1 to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (using host 127.0.0.1 to verify)
 <~  220 SERVER ESMTP ready
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]

--- a/testing/regressions/_exec-transactions/out-ref/05002.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/05002.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> QUIT
 <~  221 SERVER closing connection
 === Connection closed with child process.

--- a/testing/regressions/_exec-transactions/out-ref/05003.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/05003.stdout
@@ -5,7 +5,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> QUIT
 <~* 220 SERVER ESMTP ready
 === Connection closed with child process.

--- a/testing/regressions/_exec-transactions/out-ref/05012.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/05012.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-STARTTLS

--- a/testing/regressions/_exec-transactions/out-ref/05102.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/05102.stdout
@@ -22,5 +22,5 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
 === Dropping connection

--- a/testing/regressions/_exec-transactions/out-ref/05103.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/05103.stdout
@@ -5,5 +5,5 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
 === Dropping connection

--- a/testing/regressions/_exec-transactions/out-ref/05112.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/05112.stdout
@@ -22,7 +22,7 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 <~  250-SERVER Hello Server [1.1.1.1]
 <~  250-STARTTLS

--- a/testing/regressions/_exec-transactions/out-ref/05203.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/05203.stdout
@@ -5,5 +5,5 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
 === Dropping connection

--- a/testing/regressions/_exec-transactions/out-ref/05212.stdout
+++ b/testing/regressions/_exec-transactions/out-ref/05212.stdout
@@ -22,6 +22,6 @@
 === TLS no client certificate set
 === TLS peer[0]   subject=[/C=US/ST=Indiana/O=Swaks Development (node.example.com, with-SAN)/CN=node.example.com/emailAddress=proj-swaks@jetmore.net]
 ===               commonName=[node.example.com], subjectAltName=[DNS:node.example.com] notAfter=[2033-09-11T14:50:10Z]
-=== TLS peer certificate failed CA verification, failed host verification (no host string available to verify)
+=== TLS peer certificate failed CA verification (unable to get local issuer certificate), failed host verification (no host string available to verify)
  ~> EHLO hserver
 === Dropping connection


### PR DESCRIPTION
* Print all available certificate information even if TLS was not successfully negotiated
* Rework tls verification. On cert verification failure, print openssl's error message. (#66)
* Get rid of verify callback (#76).
* Clarify --tls-verify-ca docs, this verifies both signing and date expiration (notBefore/notAfter) (#66)